### PR TITLE
Add optional support for granular endianness

### DIFF
--- a/rkyv/src/impls/core/primitive.rs
+++ b/rkyv/src/impls/core/primitive.rs
@@ -48,9 +48,9 @@ macro_rules! impl_primitive {
             #[cfg(not(any(feature = "archive_le", feature = "archive_be")))]
             type Archived = $type;
             #[cfg(feature = "archive_le")]
-            type Archived = rend::LittleEndian<$type>;
+            type Archived = ::rend::LittleEndian<$type>;
             #[cfg(feature = "archive_be")]
-            type Archived = rend::BigEndian<$type>;
+            type Archived = ::rend::BigEndian<$type>;
 
             impl Archive for $type {
                 type Archived = Archived;
@@ -108,9 +108,9 @@ macro_rules! impl_atomic {
             #[cfg(not(any(feature = "archive_le", feature = "archive_be")))]
             type Archived = $prim;
             #[cfg(feature = "archive_le")]
-            type Archived = rend::LittleEndian<$prim>;
+            type Archived = ::rend::LittleEndian<$prim>;
             #[cfg(feature = "archive_be")]
-            type Archived = rend::BigEndian<$prim>;
+            type Archived = ::rend::BigEndian<$prim>;
 
             type Resolver = ();
 
@@ -179,6 +179,84 @@ impl_atomic!(@multibyte AtomicU16, u16);
 impl_atomic!(@multibyte AtomicU32, u32);
 #[cfg(has_atomics_64)]
 impl_atomic!(@multibyte AtomicU64, u64);
+
+#[cfg(feature = "rend")]
+pub mod rend {
+    use super::*;
+    use ::rend::*;
+
+    impl_primitive!(i16_be);
+    impl_primitive!(i32_be);
+    impl_primitive!(i64_be);
+    impl_primitive!(i128_be);
+    impl_primitive!(u16_be);
+    impl_primitive!(u32_be);
+    impl_primitive!(u64_be);
+    impl_primitive!(u128_be);
+
+    impl_primitive!(f32_be);
+    impl_primitive!(f64_be);
+
+    impl_primitive!(char_be);
+
+    impl_primitive!(NonZeroI16_be);
+    impl_primitive!(NonZeroI32_be);
+    impl_primitive!(NonZeroI64_be);
+    impl_primitive!(NonZeroI128_be);
+    impl_primitive!(NonZeroU16_be);
+    impl_primitive!(NonZeroU32_be);
+    impl_primitive!(NonZeroU64_be);
+    impl_primitive!(NonZeroU128_be);
+
+    #[cfg(has_atomics)]
+    impl_atomic!(AtomicI16_be, i16);
+    #[cfg(has_atomics)]
+    impl_atomic!(AtomicI32_be, i32);
+    #[cfg(has_atomics_64)]
+    impl_atomic!(AtomicI64_be, i64);
+    #[cfg(has_atomics)]
+    impl_atomic!(AtomicU16_be, u16);
+    #[cfg(has_atomics)]
+    impl_atomic!(AtomicU32_be, u32);
+    #[cfg(has_atomics_64)]
+    impl_atomic!(AtomicU64_be, u64);
+
+    impl_primitive!(i16_le);
+    impl_primitive!(i32_le);
+    impl_primitive!(i64_le);
+    impl_primitive!(i128_le);
+    impl_primitive!(u16_le);
+    impl_primitive!(u32_le);
+    impl_primitive!(u64_le);
+    impl_primitive!(u128_le);
+
+    impl_primitive!(f32_le);
+    impl_primitive!(f64_le);
+
+    impl_primitive!(char_le);
+
+    impl_primitive!(NonZeroI16_le);
+    impl_primitive!(NonZeroI32_le);
+    impl_primitive!(NonZeroI64_le);
+    impl_primitive!(NonZeroI128_le);
+    impl_primitive!(NonZeroU16_le);
+    impl_primitive!(NonZeroU32_le);
+    impl_primitive!(NonZeroU64_le);
+    impl_primitive!(NonZeroU128_le);
+
+    #[cfg(has_atomics)]
+    impl_atomic!(AtomicI16_le, i16);
+    #[cfg(has_atomics)]
+    impl_atomic!(AtomicI32_le, i32);
+    #[cfg(has_atomics_64)]
+    impl_atomic!(AtomicI64_le, i64);
+    #[cfg(has_atomics)]
+    impl_atomic!(AtomicU16_le, u16);
+    #[cfg(has_atomics)]
+    impl_atomic!(AtomicU32_le, u32);
+    #[cfg(has_atomics_64)]
+    impl_atomic!(AtomicU64_le, u64);
+}
 
 // PhantomData
 

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -159,6 +159,9 @@ pub mod validation;
 pub mod vec;
 pub mod with;
 
+#[cfg(feature = "rend")]
+pub use rend;
+
 use core::alloc::Layout;
 use ptr_meta::Pointee;
 pub use rkyv_derive::{Archive, Deserialize, Serialize};

--- a/rkyv_test/src/lib.rs
+++ b/rkyv_test/src/lib.rs
@@ -48,6 +48,36 @@ mod tests {
         test_archive(&Result::<i32, u32>::Ok(12345i32));
         test_archive(&Result::<i32, u32>::Err(12345u32));
         test_archive(&Some(42));
+
+        #[cfg(feature = "rkyv/rend")]
+        {
+            use rkyv::rend::*;
+            test_archive(f32_be::new(&1234567f32));
+            test_archive(f64_be::new(&12345678901234f64));
+            test_archive(i8_be::new(&123i8));
+            test_archive(i16_be::new(&12345i16));
+            test_archive(i32_be::new(&1234567890i32));
+            test_archive(i64_be::new(&1234567890123456789i64));
+            test_archive(i128_be::new(&123456789012345678901234567890123456789i128));
+            test_archive(u8_be::new(&123u8));
+            test_archive(u16_be::new(&12345u16));
+            test_archive(u32_be::new(&1234567890u32));
+            test_archive(u64_be::new(&12345678901234567890u64));
+            test_archive(u128_be::new(&123456789012345678901234567890123456789u128));
+
+            test_archive(f32_le::new(&1234567f32));
+            test_archive(f64_le::new(&12345678901234f64));
+            test_archive(i8_le::new(&123i8));
+            test_archive(i16_le::new(&12345i16));
+            test_archive(i32_le::new(&1234567890i32));
+            test_archive(i64_le::new(&1234567890123456789i64));
+            test_archive(i128_le::new(&123456789012345678901234567890123456789i128));
+            test_archive(u8_le::new(&123u8));
+            test_archive(u16_le::new(&12345u16));
+            test_archive(u32_le::new(&1234567890u32));
+            test_archive(u64_le::new(&12345678901234567890u64));
+            test_archive(u128_le::new(&123456789012345678901234567890123456789u128));
+        }
     }
 
     #[test]
@@ -97,6 +127,48 @@ mod tests {
             test_archive(&NonZeroU128::new_unchecked(
                 123456789012345678901234567890123456789,
             ));
+        }
+
+        #[cfg(feature = "rkyv/rend")]
+        unsafe {
+            use rkyv::rend::*;
+            test_archive(&NonZeroI8_be::new(NonZeroI8::new_unchecked(123)));
+            test_archive(&NonZeroI16_be::new(NonZeroI16::new_unchecked(12345)));
+            test_archive(&NonZeroI32_be::new(NonZeroI32::new_unchecked(1234567890)));
+            test_archive(&NonZeroI64_be::new(NonZeroI64::new_unchecked(
+                1234567890123456789,
+            )));
+            test_archive(&NonZeroI128_be::new(NonZeroI128::new_unchecked(
+                123456789012345678901234567890123456789,
+            )));
+            test_archive(&NonZeroU8_be::new(NonZeroU8::new_unchecked(123)));
+            test_archive(&NonZeroU16_be::new(NonZeroU16::new_unchecked(12345)));
+            test_archive(&NonZeroU32_be::new(NonZeroU32::new_unchecked(1234567890)));
+            test_archive(&NonZeroU64_be::new(NonZeroU64::new_unchecked(
+                1234567890123456789,
+            )));
+            test_archive(&NonZeroU128_be::new(NonZeroU128::new_unchecked(
+                123456789012345678901234567890123456789,
+            )));
+
+            test_archive(&NonZeroI8_le::new(NonZeroI8::new_unchecked(123)));
+            test_archive(&NonZeroI16_le::new(NonZeroI16::new_unchecked(12345)));
+            test_archive(&NonZeroI32_le::new(NonZeroI32::new_unchecked(1234567890)));
+            test_archive(&NonZeroI64_le::new(NonZeroI64::new_unchecked(
+                1234567890123456789,
+            )));
+            test_archive(&NonZeroI128_le::new(NonZeroI128::new_unchecked(
+                123456789012345678901234567890123456789,
+            )));
+            test_archive(&NonZeroU8_le::new(NonZeroU8::new_unchecked(123)));
+            test_archive(&NonZeroU16_le::new(NonZeroU16::new_unchecked(12345)));
+            test_archive(&NonZeroU32_le::new(NonZeroU32::new_unchecked(1234567890)));
+            test_archive(&NonZeroU64_le::new(NonZeroU64::new_unchecked(
+                1234567890123456789,
+            )));
+            test_archive(&NonZeroU128_le::new(NonZeroU128::new_unchecked(
+                123456789012345678901234567890123456789,
+            )));
         }
     }
 


### PR DESCRIPTION
I tried to `#[derive(Archive)]` a `u64_be` newtype and noticed it was missing, so this PR adds support for optional (feature `"endian"`) granular endianness with non-multibyte `impl_primitive` and `impl_atomic`.

I would have asked first, but it was a trivial change. I went by the existing impls assuming they matched `rend`’s API, so try and give a look and see if something needs to be added or adjusted.

rkyv is such a nice project by the way, keep up the great work!