### PR TITLE
Fix default features, default workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,9 @@
 [workspace]
-members = [
-    "examples/json",
-    "examples/opcode",
+members = ["examples/json", "examples/opcode", "rkyv*"]
+default-members = [
     "rkyv",
-    "rkyv_bench",
-    "rkyv_derive",
     "rkyv_dyn",
-    "rkyv_dyn_derive",
     "rkyv_dyn_test",
     "rkyv_test",
     "rkyv_typename",
-    "rkyv_typename_derive",
 ]

--- a/rkyv_bench/Cargo.toml
+++ b/rkyv_bench/Cargo.toml
@@ -12,12 +12,12 @@ bytecheck = "0.6.0"
 criterion = "0.3"
 rand = "0.8"
 rand_pcg = "0.3"
-rkyv = { version = "0.7.0", path = "../rkyv", features = ["validation"] }
+rkyv = { version = "0.7.0", path = "../rkyv", default-features = false, features = ["validation"] }
 rkyv_derive = { version = "0.7.0", path = "../rkyv_derive" }
 serde = { version = "1.0", features = ["derive"] }
 
 [features]
-default = []
+default = ["rkyv/size_32", "rkyv/std"]
 archive_le = ["rkyv/archive_le"]
 archive_be = ["rkyv/archive_be"]
 

--- a/rkyv_dyn/Cargo.toml
+++ b/rkyv_dyn/Cargo.toml
@@ -18,12 +18,12 @@ bytecheck = { version = "0.6", optional = true }
 inventory = "0.1"
 lazy_static = "1.4"
 ptr_meta = "~0.1.3"
-rkyv = { version = "0.7", path = "../rkyv" }
+rkyv = { version = "0.7", path = "../rkyv", default-features = false }
 rkyv_dyn_derive = { version = "=0.7.5", path = "../rkyv_dyn_derive" }
 rkyv_typename = { version = "0.7", path = "../rkyv_typename" }
 
 [features]
-default = []
+default = ["rkyv/size_32", "rkyv/std"]
 archive_le = ["rkyv/archive_le"]
 archive_be = ["rkyv/archive_be"]
 nightly = []

--- a/rkyv_dyn_test/Cargo.toml
+++ b/rkyv_dyn_test/Cargo.toml
@@ -12,13 +12,13 @@ repository = "https://github.com/rkyv/rkyv"
 [dependencies]
 bytecheck = { version = "0.6.0", optional = true }
 ptr_meta = "~0.1.3"
-rkyv = { path = "../rkyv" }
+rkyv = { path = "../rkyv", default-features = false }
 rkyv_dyn = { path = "../rkyv_dyn", default-features = false }
 rkyv_typename = { path = "../rkyv_typename", default-features = false }
 wasm-bindgen-test = { version = "0.3", optional = true }
 
 [features]
-default = ["validation"]
+default = ["rkyv/size_32", "rkyv/std", "validation"]
 archive_le = ["rkyv/archive_le", "rkyv_dyn/archive_le"]
 archive_be = ["rkyv/archive_be", "rkyv_dyn/archive_be"]
 nightly = ["rkyv_dyn/nightly"]


### PR DESCRIPTION
Enables `--no-default-features` to work across the workspace (#197) by adjusting `default-features` in `rkyv_dyn` and `rkyv_dyn_test` and making `default-members` only crates that need to be.