### PR TITLE
Add support for `Url`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ book
 Cargo.lock
 /target
 /.vscode
+/.idea
+*.iml

--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -32,6 +32,7 @@ indexmap = { version = "1.7", optional = true, default-features = false }
 smallvec = { version = "1.7", optional = true, default-features = false }
 tinyvec = { version = "1.5", optional = true, default-features = false }
 uuid = { version = "0.8", optional = true, default-features = false }
+url = { version = "2.2", optional = true, default-features = false }
 
 [features]
 default = ["size_32", "std"]

--- a/rkyv/src/impls/mod.rs
+++ b/rkyv/src/impls/mod.rs
@@ -19,5 +19,7 @@ mod indexmap;
 mod smallvec;
 #[cfg(feature = "tinyvec")]
 mod tinyvec;
+#[cfg(feature = "url")]
+mod url;
 #[cfg(feature = "uuid")]
 mod uuid;

--- a/rkyv/src/impls/url.rs
+++ b/rkyv/src/impls/url.rs
@@ -1,25 +1,74 @@
-use crate::net::{ArchivedIpv4Addr, ArchivedIpv6Addr};
-use crate::{Archive, Archived, Deserialize, Fallible, Serialize};
+use crate::out_field;
+use crate::{Archive, Deserialize, Serialize};
+use crate::{Archived, Fallible, Resolver};
+use core::mem::MaybeUninit;
+use std::io::Write;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use url::Url;
 
 impl Archive for Url {
     type Archived = ArchivedUrl;
-    type Resolver = ();
+    type Resolver = ArchivedUrlResolver;
 
-    unsafe fn resolve(&self, _: usize, _: Self::Resolver, out: *mut Self::Archived) {
-        unimplemented!()
+    unsafe fn resolve(&self, pos: usize, resolver: Self::Resolver, out: *mut Self::Archived) {
+        let mut result = MaybeUninit::<Url>::zeroed();
+        let url = result.as_mut_ptr();
+        macro_rules! resolve_foreach_field {
+            ($($field:ident),+)=> {
+                $(
+                    let (fp, fo) = out_field!(url.$field);
+                    out.$field.resolve(pos + fp, resolver.$field, fo);
+                )+
+            };
+        }
+        resolve_foreach_field![
+            serialization,
+            scheme_end,
+            username_end,
+            host_start,
+            host_end,
+            host,
+            port,
+            path_start,
+            query_start,
+            fragment_start
+        ];
     }
 }
 
+#[rustfmt::skip]
 impl<S: Fallible + ?Sized> Serialize<S> for Url {
-    fn serialize(&self, _: &mut S) -> Result<Self::Resolver, S::Error> {
-        Ok(())
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        Ok(Self::Resolver {
+            serialization: Serialize::<S>::serialize(&self.serialization, serializer)?,
+            scheme_end: Serialize::<S>::serialize(&self.scheme_end, serializer)?,
+            username_end: Serialize::<S>::serialize(&self.username_end, serializer)?,
+            host_start: Serialize::<S>::serialize(&self.host_start, serializer)?,
+            host_end: Serialize::<S>::serialize(&self.host_end, serializer)?,
+            host: Serialize::<S>::serialize(&self.host, serializer)?,
+            port: Serialize::<S>::serialize(&self.port, serializer)?,
+            path_start: Serialize::<S>::serialize(&self.path_start, serializer)?,
+            query_start: Serialize::<S>::serialize(&self.query_start, serializer)?,
+            fragment_start: Serialize::<S>::serialize(&self.fragment_start, serializer)?,
+        })
     }
 }
 
+#[rustfmt::skip]
 impl<D: Fallible + ?Sized> Deserialize<Url, D> for Url {
-    fn deserialize(&self, _: &mut D) -> Result<Url, D::Error> {
-        Ok(self.to_owned())
+    fn deserialize(&self, deserializer: &mut D) -> Result<Url, D::Error> {
+        Ok(Self {
+            serialization: Deserialize::<String, D>::deserialize(&self.serialization, deserializer)?,
+            scheme_end: Deserialize::<u32, D>::deserialize(&self.scheme_end, deserializer)?,
+            username_end: Deserialize::<u32, D>::deserialize(&self.username_end, deserializer)?,
+            host_start: Deserialize::<u32, D>::deserialize(&self.host_start, deserializer)?,
+            host_end: Deserialize::<u32, D>::deserialize(&self.host_end, deserializer)?,
+            host: Deserialize::<HostInternal, D>::deserialize(&self.host, deserializer)?,
+            port: Deserialize::<Option<u16>, D>::deserialize(&self.port, deserializer)?,
+            path_start: Deserialize::<u32, D>::deserialize(&self.path_start, deserializer)?,
+            query_start: Deserialize::<Option<u32>, D>::deserialize(&self.query_start, deserializer)?,
+            fragment_start: Deserialize::<Option<u32>, D>::deserialize(&self.fragment_start, deserializer)?,
+        })
     }
 }
 
@@ -27,32 +76,50 @@ impl<D: Fallible + ?Sized> Deserialize<Url, D> for Url {
 pub struct ArchivedUrl {
     /// Syntax in pseudo-BNF:
     ///
-    ///   url = scheme ":" [ hierarchical | non-hierarchical ] [ "?" query ]? [ "#" fragment ]?
-    ///   non-hierarchical = non-hierarchical-path
-    ///   non-hierarchical-path = /* Does not start with "/" */
-    ///   hierarchical = authority? hierarchical-path
-    ///   authority = "//" userinfo? host [ ":" port ]?
-    ///   userinfo = username [ ":" password ]? "@"
-    ///   hierarchical-path = [ "/" path-segment ]+
+    /// - url = scheme ":" [ hierarchical | non-hierarchical ] [ "?" query ]? [ "#" fragment ]?
+    /// - non-hierarchical = non-hierarchical-path
+    /// - non-hierarchical-path = /* Does not start with "/" */
+    /// - hierarchical = authority? hierarchical-path
+    /// - authority = "//" userinfo? host [ ":" port ]?
+    /// - userinfo = username [ ":" password ]? "@"
+    /// - hierarchical-path = [ "/" path-segment ]+
     serialization: Archived<String>,
 
     // Components
-    scheme_end: Archived<u32>,   // Before ':'
-    username_end: Archived<u32>, // Before ':' (if a password is given) or '@' (if not)
+    scheme_end: Archived<u32>,
+    // Before ':'
+    username_end: Archived<u32>,
+    // Before ':' (if a password is given) or '@' (if not)
     host_start: Archived<u32>,
     host_end: Archived<u32>,
-    host: ArchivedHostInternal,
+    host: Archived<HostInternal>,
     port: Archived<Option<u16>>,
-    path_start: Archived<u32>,             // Before initial '/', if any
-    query_start: Archived<Option<u32>>,    // Before '?', unlike Position::QueryStart
+    path_start: Archived<u32>,
+    // Before initial '/', if any
+    query_start: Archived<Option<u32>>,
+    // Before '?', unlike Position::QueryStart
     fragment_start: Archived<Option<u32>>, // Before '#', unlike Position::FragmentStart
 }
 
-pub enum ArchivedHostInternal {
+pub struct ArchivedUrlResolver {
+    serialization: Resolver<String>,
+    scheme_end: Resolver<u32>,
+    username_end: Resolver<u32>,
+    host_start: Resolver<u32>,
+    host_end: Resolver<u32>,
+    host: Resolver<HostInternal>,
+    port: Resolver<Option<u16>>,
+    path_start: Resolver<u32>,
+    query_start: Resolver<Option<u32>>,
+    fragment_start: Resolver<Option<u32>>,
+}
+
+#[derive(Archive, Serialize, Deserialize)]
+pub enum HostInternal {
     None,
     Domain,
-    Ipv4(ArchivedIpv4Addr),
-    Ipv6(ArchivedIpv6Addr),
+    Ipv4(Ipv4Addr),
+    Ipv6(Ipv6Addr),
 }
 
 #[cfg(test)]

--- a/rkyv/src/impls/url.rs
+++ b/rkyv/src/impls/url.rs
@@ -1,0 +1,89 @@
+use crate::net::{ArchivedIpv4Addr, ArchivedIpv6Addr};
+use crate::{Archive, Archived, Deserialize, Fallible, Serialize};
+use url::Url;
+
+impl Archive for Url {
+    type Archived = ArchivedUrl;
+    type Resolver = ();
+
+    unsafe fn resolve(&self, _: usize, _: Self::Resolver, out: *mut Self::Archived) {
+        unimplemented!()
+    }
+}
+
+impl<S: Fallible + ?Sized> Serialize<S> for Url {
+    fn serialize(&self, _: &mut S) -> Result<Self::Resolver, S::Error> {
+        Ok(())
+    }
+}
+
+impl<D: Fallible + ?Sized> Deserialize<Url, D> for Url {
+    fn deserialize(&self, _: &mut D) -> Result<Url, D::Error> {
+        Ok(self.to_owned())
+    }
+}
+
+/// A parsed URL record.
+pub struct ArchivedUrl {
+    /// Syntax in pseudo-BNF:
+    ///
+    ///   url = scheme ":" [ hierarchical | non-hierarchical ] [ "?" query ]? [ "#" fragment ]?
+    ///   non-hierarchical = non-hierarchical-path
+    ///   non-hierarchical-path = /* Does not start with "/" */
+    ///   hierarchical = authority? hierarchical-path
+    ///   authority = "//" userinfo? host [ ":" port ]?
+    ///   userinfo = username [ ":" password ]? "@"
+    ///   hierarchical-path = [ "/" path-segment ]+
+    serialization: Archived<String>,
+
+    // Components
+    scheme_end: Archived<u32>,   // Before ':'
+    username_end: Archived<u32>, // Before ':' (if a password is given) or '@' (if not)
+    host_start: Archived<u32>,
+    host_end: Archived<u32>,
+    host: ArchivedHostInternal,
+    port: Archived<Option<u16>>,
+    path_start: Archived<u32>,             // Before initial '/', if any
+    query_start: Archived<Option<u32>>,    // Before '?', unlike Position::QueryStart
+    fragment_start: Archived<Option<u32>>, // Before '#', unlike Position::FragmentStart
+}
+
+pub enum ArchivedHostInternal {
+    None,
+    Domain,
+    Ipv4(ArchivedIpv4Addr),
+    Ipv6(ArchivedIpv6Addr),
+}
+
+#[cfg(test)]
+mod rkyv_tests {
+    use crate::{
+        archived_root,
+        ser::{serializers::AlignedSerializer, Serializer},
+        util::AlignedVec,
+        Deserialize, Infallible,
+    };
+    use std::str::FromStr;
+    use url::Url;
+
+    #[test]
+    fn test_serialize_deserialize() {
+        let url_str = "file://example/path";
+        let u = Url::from_str(url_str).unwrap();
+
+        let mut serializer = AlignedSerializer::new(AlignedVec::new());
+        serializer
+            .serialize_value(&u)
+            .expect("failed to archive Url");
+        let buf = serializer.into_inner();
+        let archived = unsafe { archived_root::<Url>(buf.as_ref()) };
+
+        assert_eq!(&u, archived);
+
+        let deserialized = archived
+            .deserialize(&mut Infallible)
+            .expect("failed to deserialize Url");
+
+        assert_eq!(u, deserialized);
+    }
+}

--- a/rkyv/src/vec.rs
+++ b/rkyv/src/vec.rs
@@ -122,7 +122,10 @@ impl<T> ArchivedVec<T> {
     /// situations where copying uninitialized bytes the output is acceptable, this function may be
     /// used with types that contain padding bytes.
     #[inline]
-    pub unsafe fn serialize_copy_from_slice<U: Serialize<S, Archived = T>, S: Serializer + ?Sized>(
+    pub unsafe fn serialize_copy_from_slice<
+        U: Serialize<S, Archived = T>,
+        S: Serializer + ?Sized,
+    >(
         slice: &[U],
         serializer: &mut S,
     ) -> Result<VecResolver, S::Error> {
@@ -133,9 +136,7 @@ impl<T> ArchivedVec<T> {
         let bytes = from_raw_parts(slice.as_ptr().cast::<u8>(), size_of::<T>() * slice.len());
         serializer.write(bytes)?;
 
-        Ok(VecResolver {
-            pos,
-        })
+        Ok(VecResolver { pos })
     }
 
     /// Serializes an archived `Vec` from a given iterator.

--- a/rkyv/src/with/alloc.rs
+++ b/rkyv/src/with/alloc.rs
@@ -344,18 +344,13 @@ where
     T: Serialize<S>,
     S: Serializer,
 {
-    fn serialize_with(
-        field: &Vec<T>,
-        serializer: &mut S,
-    ) -> Result<Self::Resolver, S::Error> {
+    fn serialize_with(field: &Vec<T>, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
         use ::core::mem::size_of;
 
         // Basic debug assert that T and T::Archived are at least the same size
         debug_assert_eq!(size_of::<T>(), size_of::<T::Archived>());
 
-        unsafe {
-            ArchivedVec::serialize_copy_from_slice(field.as_slice(), serializer)
-        }
+        unsafe { ArchivedVec::serialize_copy_from_slice(field.as_slice(), serializer) }
     }
 }
 
@@ -365,11 +360,8 @@ where
     T::Archived: Deserialize<T, D>,
     D: Fallible + ?Sized,
 {
-    fn deserialize_with(
-        field: &ArchivedVec<T::Archived>,
-        _: &mut D,
-    ) -> Result<Vec<T>, D::Error> {
-        use ::core::{ptr::copy_nonoverlapping, mem::size_of};
+    fn deserialize_with(field: &ArchivedVec<T::Archived>, _: &mut D) -> Result<Vec<T>, D::Error> {
+        use ::core::{mem::size_of, ptr::copy_nonoverlapping};
 
         // Basic debug assert that T and T::Archived are at least the same size
         debug_assert_eq!(size_of::<T>(), size_of::<T::Archived>());

--- a/rkyv/src/with/mod.rs
+++ b/rkyv/src/with/mod.rs
@@ -484,7 +484,7 @@ pub struct AsVec;
 pub struct Niche;
 
 /// A wrapper that provides specialized, performant implementations of serialization and
-/// deserialization. 
+/// deserialization.
 ///
 /// This wrapper can be used with containers like `Vec`, but care must be taken to ensure that they
 /// contain copy-safe types. Copy-safe types must be trivially copyable (have the same archived and


### PR DESCRIPTION
I need to serialize `Rc<Url>` when persisting `lsp_types`

So I need url support.

```yaml
error[E0277]: the trait bound `lsp_types::Url: rkyv::Archive` is not satisfied
  --> projects\ygg-bootstript\src\manager\mod.rs:19:10
   |
19 | #[derive(Archive, Deserialize, Serialize, Debug, PartialEq)]
   |          ^^^^^^^ the trait `rkyv::Archive` is not implemented for `lsp_types::Url`
   |
   = note: required because of the requirements on the impl of `rkyv::Archive` for `HashMap<lsp_types::Url, FileStore>`
   = help: see issue #48214
   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
   = note: this error originates in the derive macro `Archive` (in Nightly builds, run with -Z macro-backtrace for more info)

   error[E0277]: the trait bound `lsp_types::Url: rkyv::Archive` is not satisfied
   --> projects\ygg-bootstript\src\manager\mod.rs:19:19
    |
 19 | #[derive(Archive, Deserialize, Serialize, Debug, PartialEq)]
    |                   ^^^^^^^^^^^ the trait `rkyv::Archive` is not implemented for `lsp_types::Url`
    |
    = note: required because of the requirements on the impl of `rkyv::Archive` for `HashMap<lsp_types::Url, FileStore>`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
    error[E0277]: the trait bound `lsp_types::Url: rkyv::Archive` is not satisfied
    --> projects\ygg-bootstript\src\manager\mod.rs:19:32
     |
  19 | #[derive(Archive, Deserialize, Serialize, Debug, PartialEq)]
     |                                ^^^^^^^^^ the trait `rkyv::Archive` is not implemented for `lsp_types::Url`
     |
     = note: required because of the requirements on the impl of `rkyv::Archive` for `HashMap<lsp_types::Url, FileStore>`
     = help: see issue #48214
     = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     = note: this error originates in the derive macro `Serialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```