### PR TITLE
Add ability to use scratch space via a mutable reference.

### DIFF
--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -194,6 +194,10 @@ pub trait Fallible {
     type Error: 'static;
 }
 
+impl<T: ?Sized + Fallible> Fallible for &mut T {
+    type Error = T::Error;
+}
+
 /// A fallible type that cannot produce errors.
 ///
 /// This type can be used to serialize and deserialize types that cannot fail to serialize or

--- a/rkyv/src/ser/mod.rs
+++ b/rkyv/src/ser/mod.rs
@@ -141,6 +141,16 @@ pub trait ScratchSpace: Fallible {
     unsafe fn pop_scratch(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), Self::Error>;
 }
 
+impl<T: ?Sized + ScratchSpace> ScratchSpace for &mut T {
+    unsafe fn push_scratch(&mut self, layout: Layout) -> Result<NonNull<[u8]>, Self::Error> {
+        (&mut **self).push_scratch(layout)
+    }
+
+    unsafe fn pop_scratch(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), Self::Error> {
+        (&mut **self).pop_scratch(ptr, layout)
+    }
+}
+
 /// A registry that tracks serialized shared memory.
 ///
 /// This trait is required to serialize shared pointers.


### PR DESCRIPTION
Exactly what it says on the tin.  Related to this: https://github.com/Kixiron/ddshow/blob/master/crates/ddshow-sink/src/writer.rs#L92

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>