### PR TITLE
add impl for with::Map

### DIFF
--- a/rkyv/src/with/core.rs
+++ b/rkyv/src/with/core.rs
@@ -6,21 +6,23 @@ use crate::{
         ArchivedOptionNonZeroU16, ArchivedOptionNonZeroU32, ArchivedOptionNonZeroU64,
         ArchivedOptionNonZeroU8,
     },
-    with::{ArchiveWith, AsBox, DeserializeWith, Inline, Map, Niche, RefAsBox, SerializeWith, Unsafe},
-    Archive, ArchiveUnsized, Deserialize, Fallible, Serialize, SerializeUnsized,
     option::ArchivedOption,
+    ser::{ScratchSpace, Serializer},
     vec::{ArchivedVec, VecResolver},
-    ser::{Serializer, ScratchSpace},
+    with::{
+        ArchiveWith, AsBox, DeserializeWith, Inline, Map, Niche, RefAsBox, SerializeWith, Unsafe,
+    },
+    Archive, ArchiveUnsized, Deserialize, Fallible, Serialize, SerializeUnsized,
 };
 use ::core::{
     cell::{Cell, UnsafeCell},
     convert::TryInto,
+    hint::unreachable_unchecked,
+    marker::PhantomData,
     num::{
         NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
         NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
     },
-    marker::PhantomData,
-    hint::unreachable_unchecked,
     ptr,
 };
 
@@ -85,8 +87,7 @@ where
     }
 }
 
-impl<A, O, D> DeserializeWith<ArchivedVec<<A as ArchiveWith<O>>::Archived>, Vec<O>, D>
-    for Map<A>
+impl<A, O, D> DeserializeWith<ArchivedVec<<A as ArchiveWith<O>>::Archived>, Vec<O>, D> for Map<A>
 where
     A: ArchiveWith<O> + DeserializeWith<<A as ArchiveWith<O>>::Archived, O, D>,
     D: Fallible,

--- a/rkyv/src/with/core.rs
+++ b/rkyv/src/with/core.rs
@@ -7,8 +7,6 @@ use crate::{
         ArchivedOptionNonZeroU8,
     },
     option::ArchivedOption,
-    ser::{ScratchSpace, Serializer},
-    vec::{ArchivedVec, VecResolver},
     with::{
         ArchiveWith, AsBox, DeserializeWith, Inline, Map, Niche, RefAsBox, SerializeWith, Unsafe,
     },
@@ -18,90 +16,12 @@ use ::core::{
     cell::{Cell, UnsafeCell},
     convert::TryInto,
     hint::unreachable_unchecked,
-    marker::PhantomData,
     num::{
         NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
         NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
     },
     ptr,
 };
-
-// Map for Vecs
-
-impl<A, O> ArchiveWith<Vec<O>> for Map<A>
-where
-    A: ArchiveWith<O>,
-{
-    type Archived = ArchivedVec<<A as ArchiveWith<O>>::Archived>;
-    type Resolver = VecResolver;
-
-    unsafe fn resolve_with(
-        field: &Vec<O>,
-        pos: usize,
-        resolver: Self::Resolver,
-        out: *mut Self::Archived,
-    ) {
-        ArchivedVec::resolve_from_len(field.len(), pos, resolver, out)
-    }
-}
-
-impl<A, O, S> SerializeWith<Vec<O>, S> for Map<A>
-where
-    S: Fallible + ScratchSpace + Serializer,
-    A: ArchiveWith<O> + SerializeWith<O, S>,
-{
-    fn serialize_with(field: &Vec<O>, s: &mut S) -> Result<Self::Resolver, S::Error> {
-        // Wrapper for O so that we have an Archive and Serialize implementation
-        // and ArchivedVec::serialize_from_* is happy about the bound constraints
-        struct RefWrapper<'o, A, O>(&'o O, PhantomData<A>);
-
-        impl<A: ArchiveWith<O>, O> Archive for RefWrapper<'_, A, O> {
-            type Archived = <A as ArchiveWith<O>>::Archived;
-            type Resolver = <A as ArchiveWith<O>>::Resolver;
-
-            unsafe fn resolve(
-                &self,
-                pos: usize,
-                resolver: Self::Resolver,
-                out: *mut Self::Archived,
-            ) {
-                A::resolve_with(self.0, pos, resolver, out)
-            }
-        }
-
-        impl<A, O, S> Serialize<S> for RefWrapper<'_, A, O>
-        where
-            A: ArchiveWith<O> + SerializeWith<O, S>,
-            S: Fallible + Serializer,
-        {
-            fn serialize(&self, s: &mut S) -> Result<Self::Resolver, S::Error> {
-                A::serialize_with(self.0, s)
-            }
-        }
-
-        let iter = field
-            .iter()
-            .map(|value| RefWrapper::<'_, A, O>(value, PhantomData));
-
-        ArchivedVec::serialize_from_iter(iter, s)
-    }
-}
-
-impl<A, O, D> DeserializeWith<ArchivedVec<<A as ArchiveWith<O>>::Archived>, Vec<O>, D> for Map<A>
-where
-    A: ArchiveWith<O> + DeserializeWith<<A as ArchiveWith<O>>::Archived, O, D>,
-    D: Fallible,
-{
-    fn deserialize_with(
-        field: &ArchivedVec<<A as ArchiveWith<O>>::Archived>,
-        d: &mut D,
-    ) -> Result<Vec<O>, D::Error> {
-        field
-            .iter()
-            .map(|value| <A as DeserializeWith<_, _, D>>::deserialize_with(value, d))
-            .collect()
-    }
-}
 
 // Map for Options
 

--- a/rkyv/src/with/core.rs
+++ b/rkyv/src/with/core.rs
@@ -6,8 +6,11 @@ use crate::{
         ArchivedOptionNonZeroU16, ArchivedOptionNonZeroU32, ArchivedOptionNonZeroU64,
         ArchivedOptionNonZeroU8,
     },
-    with::{ArchiveWith, AsBox, DeserializeWith, Inline, Niche, RefAsBox, SerializeWith, Unsafe},
+    with::{ArchiveWith, AsBox, DeserializeWith, Inline, Map, Niche, RefAsBox, SerializeWith, Unsafe},
     Archive, ArchiveUnsized, Deserialize, Fallible, Serialize, SerializeUnsized,
+    option::ArchivedOption,
+    vec::{ArchivedVec, VecResolver},
+    ser::{Serializer, ScratchSpace},
 };
 use ::core::{
     cell::{Cell, UnsafeCell},
@@ -16,7 +19,168 @@ use ::core::{
         NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
         NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
     },
+    marker::PhantomData,
+    hint::unreachable_unchecked,
+    ptr,
 };
+
+// Map for Vecs
+
+impl<A, O> ArchiveWith<Vec<O>> for Map<A>
+where
+    A: ArchiveWith<O>,
+{
+    type Archived = ArchivedVec<<A as ArchiveWith<O>>::Archived>;
+    type Resolver = VecResolver;
+
+    unsafe fn resolve_with(
+        field: &Vec<O>,
+        pos: usize,
+        resolver: Self::Resolver,
+        out: *mut Self::Archived,
+    ) {
+        ArchivedVec::resolve_from_len(field.len(), pos, resolver, out)
+    }
+}
+
+impl<A, O, S> SerializeWith<Vec<O>, S> for Map<A>
+where
+    S: Fallible + ScratchSpace + Serializer,
+    A: ArchiveWith<O> + SerializeWith<O, S>,
+{
+    fn serialize_with(field: &Vec<O>, s: &mut S) -> Result<Self::Resolver, S::Error> {
+        // Wrapper for O so that we have an Archive and Serialize implementation
+        // and ArchivedVec::serialize_from_* is happy about the bound constraints
+        struct RefWrapper<'o, A, O>(&'o O, PhantomData<A>);
+
+        impl<A: ArchiveWith<O>, O> Archive for RefWrapper<'_, A, O> {
+            type Archived = <A as ArchiveWith<O>>::Archived;
+            type Resolver = <A as ArchiveWith<O>>::Resolver;
+
+            unsafe fn resolve(
+                &self,
+                pos: usize,
+                resolver: Self::Resolver,
+                out: *mut Self::Archived,
+            ) {
+                A::resolve_with(self.0, pos, resolver, out)
+            }
+        }
+
+        impl<A, O, S> Serialize<S> for RefWrapper<'_, A, O>
+        where
+            A: ArchiveWith<O> + SerializeWith<O, S>,
+            S: Fallible + Serializer,
+        {
+            fn serialize(&self, s: &mut S) -> Result<Self::Resolver, S::Error> {
+                A::serialize_with(self.0, s)
+            }
+        }
+
+        let iter = field
+            .iter()
+            .map(|value| RefWrapper::<'_, A, O>(value, PhantomData));
+
+        ArchivedVec::serialize_from_iter(iter, s)
+    }
+}
+
+impl<A, O, D> DeserializeWith<ArchivedVec<<A as ArchiveWith<O>>::Archived>, Vec<O>, D>
+    for Map<A>
+where
+    A: ArchiveWith<O> + DeserializeWith<<A as ArchiveWith<O>>::Archived, O, D>,
+    D: Fallible,
+{
+    fn deserialize_with(
+        field: &ArchivedVec<<A as ArchiveWith<O>>::Archived>,
+        d: &mut D,
+    ) -> Result<Vec<O>, D::Error> {
+        field
+            .iter()
+            .map(|value| <A as DeserializeWith<_, _, D>>::deserialize_with(value, d))
+            .collect()
+    }
+}
+
+// Map for Options
+
+// Copy-paste from Option's impls for the most part
+impl<A, O> ArchiveWith<Option<O>> for Map<A>
+where
+    A: ArchiveWith<O>,
+{
+    type Archived = ArchivedOption<<A as ArchiveWith<O>>::Archived>;
+    type Resolver = Option<<A as ArchiveWith<O>>::Resolver>;
+
+    unsafe fn resolve_with(
+        field: &Option<O>,
+        pos: usize,
+        resolver: Self::Resolver,
+        out: *mut Self::Archived,
+    ) {
+        match resolver {
+            None => {
+                let out = out.cast::<ArchivedOptionVariantNone>();
+                ptr::addr_of_mut!((*out).0).write(ArchivedOptionTag::None);
+            }
+            Some(resolver) => {
+                let out = out.cast::<ArchivedOptionVariantSome<<A as ArchiveWith<O>>::Archived>>();
+                ptr::addr_of_mut!((*out).0).write(ArchivedOptionTag::Some);
+
+                let value = if let Some(value) = field.as_ref() {
+                    value
+                } else {
+                    unreachable_unchecked();
+                };
+
+                let (fp, fo) = out_field!(out.1);
+                A::resolve_with(value, pos + fp, resolver, fo);
+            }
+        }
+    }
+}
+
+impl<A, O, S> SerializeWith<Option<O>, S> for Map<A>
+where
+    S: Fallible,
+    A: ArchiveWith<O> + SerializeWith<O, S>,
+{
+    fn serialize_with(field: &Option<O>, s: &mut S) -> Result<Self::Resolver, S::Error> {
+        field
+            .as_ref()
+            .map(|value| A::serialize_with(value, s))
+            .transpose()
+    }
+}
+
+impl<A, O, D> DeserializeWith<ArchivedOption<<A as ArchiveWith<O>>::Archived>, Option<O>, D>
+    for Map<A>
+where
+    D: Fallible,
+    A: ArchiveWith<O> + DeserializeWith<<A as ArchiveWith<O>>::Archived, O, D>,
+{
+    fn deserialize_with(
+        field: &ArchivedOption<<A as ArchiveWith<O>>::Archived>,
+        d: &mut D,
+    ) -> Result<Option<O>, D::Error> {
+        match field {
+            ArchivedOption::Some(value) => Ok(Some(A::deserialize_with(value, d)?)),
+            ArchivedOption::None => Ok(None),
+        }
+    }
+}
+
+#[repr(u8)]
+enum ArchivedOptionTag {
+    None,
+    Some,
+}
+
+#[repr(C)]
+struct ArchivedOptionVariantNone(ArchivedOptionTag);
+
+#[repr(C)]
+struct ArchivedOptionVariantSome<T>(ArchivedOptionTag, T);
 
 // Inline
 

--- a/rkyv/src/with/mod.rs
+++ b/rkyv/src/with/mod.rs
@@ -292,7 +292,6 @@ pub struct Map<Archivable> {
     _type: PhantomData<Archivable>,
 }
 
-
 /// A wrapper that archives an atomic with an underlying atomic.
 ///
 /// By default, atomics are archived with an underlying integer.

--- a/rkyv/src/with/mod.rs
+++ b/rkyv/src/with/mod.rs
@@ -274,6 +274,25 @@ const _: () = {
     }
 };
 
+/// A generic wrapper that allows wrapping an Option<T>.
+///
+/// # Example
+///
+/// ```
+/// use rkyv::{Archive, with::{Map, RefAsBox}};
+///
+/// #[derive(Archive)]
+/// struct Example<'a> {
+///     #[with(Map<RefAsBox>)]
+///     a: &'a i32,
+/// }
+/// ```
+#[derive(Debug)]
+pub struct Map<Archivable> {
+    _type: PhantomData<Archivable>,
+}
+
+
 /// A wrapper that archives an atomic with an underlying atomic.
 ///
 /// By default, atomics are archived with an underlying integer.

--- a/rkyv/src/with/mod.rs
+++ b/rkyv/src/with/mod.rs
@@ -284,7 +284,9 @@ const _: () = {
 /// #[derive(Archive)]
 /// struct Example<'a> {
 ///     #[with(Map<RefAsBox>)]
-///     a: &'a i32,
+///     option: Option<&'a i32>,
+///     #[with(Map<RefAsBox>)]
+///     vec: Vec<&'a i32>,
 /// }
 /// ```
 #[derive(Debug)]


### PR DESCRIPTION
Added this to core: https://gist.github.com/djkoloski/880e809f2ba3fcff7d6f2b53a0cb6ef3

Allows stuff like this:
```rust
use rkyv::{Archive, with::{Map, RefAsBox}};
#[derive(Archive)]
struct Example<'a> {
    #[with(Map<RefAsBox>)]
    option: Option<&'a i32>,
    #[with(Map<RefAsBox>)]
    vec: Vec<&'a i32>,
}
```
Its probably not perfect, but its a start.