### PR TITLE
Update uuid to 1.0

### DIFF
--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -31,7 +31,7 @@ seahash = "4.0"
 indexmap = { version = "1.7", optional = true, default-features = false }
 smallvec = { version = "1.7", optional = true, default-features = false }
 tinyvec = { version = "1.5", optional = true, default-features = false }
-uuid = { version = "0.8", optional = true, default-features = false }
+uuid = { version = "1.0", optional = true, default-features = false }
 
 [features]
 default = ["size_32", "std"]


### PR DESCRIPTION
Updates uuid dependency to the latest released version (1.0) . This is a breaking change if you export the dependency. 

I don't think any more changes are required