### PR TITLE
impl Archive, Deserialize, and Serialize for AlignedBytes and AlignedVec

### DIFF
--- a/rkyv/src/util/aligned_vec.rs
+++ b/rkyv/src/util/aligned_vec.rs
@@ -84,16 +84,16 @@ impl AlignedVec {
     /// assert_eq!(vec.capacity(), 16);
     ///
     /// // These are all done without reallocating...
-    /// for i in 0..10 {
+    /// for i in 0..16 {
     ///     vec.push(i);
     /// }
-    /// assert_eq!(vec.len(), 10);
+    /// assert_eq!(vec.len(), 16);
     /// assert_eq!(vec.capacity(), 16);
     ///
     /// // ...but this may make the vector reallocate
-    /// vec.push(11);
-    /// assert_eq!(vec.len(), 11);
-    /// assert!(vec.capacity() >= 11);
+    /// vec.push(16);
+    /// assert_eq!(vec.len(), 17);
+    /// assert!(vec.capacity() >= 17);
     /// ```
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
@@ -132,11 +132,11 @@ impl AlignedVec {
     /// ```
     /// use rkyv::AlignedVec;
     ///
-    /// let mut vec = AlignedVec::with_capacity(10);
+    /// let mut vec = AlignedVec::with_capacity(17);
     /// vec.extend_from_slice(&[1, 2, 3]);
-    /// assert_eq!(vec.capacity(), 16);
+    /// assert_eq!(vec.capacity(), 32);
     /// vec.shrink_to_fit();
-    /// assert!(vec.capacity() >= 3);
+    /// assert_eq!(vec.capacity(), 16);
     /// ```
     #[inline]
     pub fn shrink_to_fit(&mut self) {
@@ -389,7 +389,7 @@ impl AlignedVec {
         unsafe {
             self.as_mut_ptr().add(self.len).write(value);
         }
-        self.len += 1;
+        unsafe { self.set_len(self.len + 1) };
     }
 
     /// Reserves the minimum capacity for exactly `additional` more elements to be inserted in the

--- a/rkyv/src/util/mod.rs
+++ b/rkyv/src/util/mod.rs
@@ -217,7 +217,8 @@ pub unsafe fn archived_unsized_root_mut<T: ArchiveUnsized + ?Sized>(
 /// assert_eq!(mem::align_of::<u8>(), 1);
 /// assert_eq!(mem::align_of::<AlignedBytes<256>>(), 16);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Archive, Clone, Copy, Debug, Deserialize, Serialize)]
+#[archive(crate = "crate")]
 #[repr(C, align(16))]
 pub struct AlignedBytes<const N: usize>(pub [u8; N]);
 

--- a/rkyv/src/vec/mod.rs
+++ b/rkyv/src/vec/mod.rs
@@ -92,7 +92,7 @@ impl<T> ArchivedVec<T> {
     /// # Safety
     ///
     /// - `pos` must be the position of `out` within the archive
-    /// - `resolver` must bet he result of serializing `value`
+    /// - `resolver` must be the result of serializing `value`
     #[inline]
     pub unsafe fn resolve_from_len(len: usize, pos: usize, resolver: VecResolver, out: *mut Self) {
         let (fp, fo) = out_field!(out.ptr);

--- a/rkyv_dyn/src/validation.rs
+++ b/rkyv_dyn/src/validation.rs
@@ -367,13 +367,11 @@ impl fmt::Display for DynMetadataError {
                 type_id,
                 expected,
                 found,
-            } => {
-                write!(
-                    f,
-                    "mismatched cached vtable for {}: expected {} but found {}",
-                    type_id, expected, found
-                )
-            }
+            } => write!(
+                f,
+                "mismatched cached vtable for {}: expected {} but found {}",
+                type_id, expected, found
+            ),
         }
     }
 }


### PR DESCRIPTION
The implementation strategy is to derive all of these trait impls. This
was straightforward for AlignedBytes since it is just POD, but it
required a little more effort for AlignedVec. Thankfully, by changing
the representation of AlignedVec to use an internal
Vec<AlignedBytes<16>>, most of the code got simpler. All of the manual
allocations went away, and much of the unsafe code went with it.

This does include a change to some of the test's expectations about what
should be returned by AlignedVec::capacity. Now, capacity is always a
multiple of ALIGNMENT=16. It is unlikely that anyone relied upon the
exact capacity. I think so long as reserve and reserve_exact follow the
same contract of reserving "enough" space for the additional bytes, we
do not need to call this a breaking change.

ArchivedAlignedVec also got some manual trait impls, similar to what
ArchivedVec has, and those impls were mostly copied from those of
ArchivedVec.