### PR TITLE
add BitVec support

### DIFF
--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -49,7 +49,7 @@ std = ["alloc", "bytecheck/std", "ptr_meta/std", "rend/std"]
 strict = ["rkyv_derive/strict"]
 validation = ["alloc", "bytecheck", "rend/validation"]
 
-bitvec_std = ["bitvec/std"]
+bitvec_alloc = ["bitvec/alloc"]
 tinyvec_alloc = ["tinyvec/alloc"]
 uuid_std = ["uuid/std"]
 

--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -28,6 +28,7 @@ seahash = "4.0"
 # implementations should be moved into their respective crates over time. Before adding support for
 # another crate, please consider getting rkyv support in the crate instead.
 
+bitvec = { version = "1.0", optional = true, default-features = false }
 indexmap = { version = "1.7", optional = true, default-features = false }
 smallvec = { version = "1.7", optional = true, default-features = false }
 tinyvec = { version = "1.5", optional = true, default-features = false }
@@ -48,6 +49,7 @@ std = ["alloc", "bytecheck/std", "ptr_meta/std", "rend/std"]
 strict = ["rkyv_derive/strict"]
 validation = ["alloc", "bytecheck", "rend/validation"]
 
+bitvec_std = ["bitvec/std"]
 tinyvec_alloc = ["tinyvec/alloc"]
 uuid_std = ["uuid/std"]
 

--- a/rkyv/src/bitvec.rs
+++ b/rkyv/src/bitvec.rs
@@ -1,0 +1,25 @@
+//! Archived bitwise containers.
+
+use crate::{Archived, vec::ArchivedVec};
+use bitvec::{order::{BitOrder, Lsb0}, slice::BitSlice, store::BitStore, view::BitView};
+use core::{marker::PhantomData, ops::Deref};
+
+/// An archived `BitVec`.
+// We also have to store the bit length in the archived `BitVec`.
+// This is because when calling `as_raw_slice` we will get unwanted bits if the `BitVec` bit length is not a multiple of the bit size of T.
+#[cfg_attr(feature = "validation", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "strict", repr(C))]
+#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ArchivedBitVec<T = Archived<usize>, O = Lsb0> {
+    pub(crate) inner: ArchivedVec<T>,
+    pub(crate) bit_len: Archived<usize>,
+    pub(crate) _or: PhantomData<O>,
+}
+
+impl<T: BitStore, O: BitOrder> Deref for ArchivedBitVec<T, O> {
+    type Target = BitSlice<T, O>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.view_bits::<O>()[..self.bit_len as usize]
+    }
+}

--- a/rkyv/src/impls/bitvec.rs
+++ b/rkyv/src/impls/bitvec.rs
@@ -1,0 +1,205 @@
+use core::convert::{TryFrom, TryInto};
+use core::{marker::PhantomData, ops::Deref};
+
+#[cfg(feature = "bitvec_std")]
+use crate::vec::{ArchivedVec, VecResolver};
+
+use crate::{
+    out_field,
+    ser::{ScratchSpace, Serializer},
+    Archive, Archived, Deserialize, Fallible, Serialize,
+};
+
+use bitvec::{prelude::*, view::BitViewSized};
+
+/// An archived `BitVec`.
+// We also have to store the bit length in the archived `BitVec`.
+// This is because when calling `as_raw_slice` we will get unwanted bits if the `BitVec` bit length is not a multiple of the bit size of T.
+#[cfg(feature = "bitvec_std")]
+#[cfg_attr(feature = "validation", derive(bytecheck::CheckBytes))]
+pub struct ArchivedBitVec<T = Archived<usize>, O = Lsb0>
+where
+    T: BitStore,
+    O: BitOrder,
+{
+    inner: ArchivedVec<T>,
+    bit_len: Archived<usize>,
+    _or: PhantomData<O>,
+}
+
+#[cfg(feature = "bitvec_std")]
+impl<T: BitStore + Archive, O: BitOrder> ArchivedBitVec<T, O> {
+    /// Gets the elements of the archived `BitVec` as a `BitSlice`.
+    pub fn as_bitslice(&self) -> &BitSlice<T, O> {
+        self.deref()
+    }
+}
+
+#[cfg(feature = "bitvec_std")]
+impl<T: BitStore + Archive, O: BitOrder> Deref for ArchivedBitVec<T, O> {
+    type Target = BitSlice<T, O>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.view_bits::<O>()[..self.bit_len as usize]
+    }
+}
+
+#[cfg(feature = "bitvec_std")]
+impl<T: BitStore + Archive, O: BitOrder> Archive for BitVec<T, O>
+where
+    Archived<T>: BitStore,
+{
+    type Archived = ArchivedBitVec<Archived<T>, O>;
+    type Resolver = VecResolver;
+
+    unsafe fn resolve(&self, pos: usize, resolver: Self::Resolver, out: *mut Self::Archived) {
+        let (fp, fo) = out_field!(out.inner);
+        ArchivedVec::resolve_from_slice(self.as_raw_slice(), pos + fp, resolver, fo);
+        let (fp, fo) = out_field!(out.bit_len);
+        usize::resolve(&self.len(), pos + fp, (), fo);
+    }
+}
+
+#[cfg(feature = "bitvec_std")]
+impl<
+        T: BitStore + Archive + Serialize<S>,
+        O: BitOrder,
+        S: Fallible + ?Sized + ScratchSpace + Serializer,
+    > Serialize<S> for BitVec<T, O>
+where
+    Archived<T>: BitStore,
+{
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, <S as Fallible>::Error> {
+        let resolver = ArchivedVec::serialize_from_slice(self.as_raw_slice(), serializer)?;
+        usize::serialize(&self.len(), serializer)?;
+
+        Ok(resolver)
+    }
+}
+
+#[cfg(feature = "bitvec_std")]
+impl<T: BitStore + Archive, O: BitOrder, D: Fallible + ?Sized> Deserialize<BitVec<T, O>, D>
+    for ArchivedBitVec<Archived<T>, O>
+where
+    Archived<T>: Deserialize<T, D> + BitStore,
+{
+    fn deserialize(&self, deserializer: &mut D) -> Result<BitVec<T, O>, <D as Fallible>::Error> {
+        let vec = ArchivedVec::deserialize(&self.inner, deserializer)?;
+        let bit_len = Archived::<usize>::deserialize(&self.bit_len, deserializer)?;
+
+        let mut bitvec = BitVec::<T, O>::from_vec(vec);
+        bitvec.truncate(bit_len);
+        Ok(bitvec)
+    }
+}
+
+#[cfg_attr(feature = "validation", derive(bytecheck::CheckBytes))]
+pub struct ArchivedBitArray<A = [Archived<usize>; 1], O = Lsb0>
+where
+    A: BitViewSized,
+    O: BitOrder,
+{
+    inner: A,
+    _or: PhantomData<O>,
+}
+
+impl<A: BitViewSized + Archive, O: BitOrder> ArchivedBitArray<A, O> {
+    /// Gets the elements of the archived `BitArray` as a `BitSlice`.
+    pub fn as_bitslice(&self) -> &BitSlice<A::Store, O> {
+        self.deref()
+    }
+}
+
+impl<A: BitViewSized + Archive, O: BitOrder> Deref for ArchivedBitArray<A, O> {
+    type Target = BitSlice<A::Store, O>;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.view_bits::<O>()
+    }
+}
+
+impl<A: BitViewSized + Archive, O: BitOrder> Archive for BitArray<A, O>
+where
+    Archived<A>: BitViewSized,
+    for<'a> &'a A: TryFrom<&'a [A::Store]>,
+{
+    type Archived = ArchivedBitArray<Archived<A>, O>;
+    type Resolver = A::Resolver;
+
+    unsafe fn resolve(&self, pos: usize, resolver: Self::Resolver, out: *mut Self::Archived) {
+        let arr_ref = self.as_raw_slice().try_into().ok().unwrap();
+
+        let (fp, fo) = out_field!(out.inner);
+        A::resolve(arr_ref, pos + fp, resolver, fo);
+    }
+}
+
+impl<
+        A: BitViewSized + Archive + Serialize<S>,
+        O: BitOrder,
+        S: Fallible + ?Sized + ScratchSpace + Serializer,
+    > Serialize<S> for BitArray<A, O>
+where
+    Archived<A>: BitViewSized,
+    for<'a> &'a A: TryFrom<&'a [A::Store]>,
+{
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, <S as Fallible>::Error> {
+        let arr_ref = self.as_raw_slice().try_into().ok().unwrap();
+        let resolver = A::serialize(arr_ref, serializer)?;
+
+        Ok(resolver)
+    }
+}
+
+impl<A: BitViewSized + Archive, O: BitOrder, D: Fallible + ?Sized> Deserialize<BitArray<A, O>, D>
+    for ArchivedBitArray<Archived<A>, O>
+where
+    Archived<A>: Deserialize<A, D> + BitViewSized,
+{
+    fn deserialize(&self, deserializer: &mut D) -> Result<BitArray<A, O>, <D as Fallible>::Error> {
+        let arr = Archived::<A>::deserialize(&self.inner, deserializer)?;
+        Ok(arr.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        archived_root,
+        ser::{serializers::AllocSerializer, Serializer},
+        Deserialize, Infallible,
+    };
+    use bitvec::prelude::*;
+
+    #[cfg(feature = "bitvec_std")]
+    #[test]
+    fn bitvec() {
+        let mut serializer = AllocSerializer::<256>::default();
+        let original = bitvec![1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1];
+
+        serializer.serialize_value(&original).unwrap();
+        let buffer = serializer.into_serializer().into_inner();
+
+        let output = unsafe { archived_root::<BitVec>(&buffer) };
+        assert_eq!(&original, output.as_bitslice());
+
+        let deserialized: BitVec = output.deserialize(&mut Infallible).unwrap();
+        assert_eq!(deserialized, original);
+    }
+
+    #[test]
+    fn bitarr() {
+        let mut serializer = AllocSerializer::<256>::default();
+
+        let original = bitarr![1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1];
+
+        serializer.serialize_value(&original).unwrap();
+        let buffer = serializer.into_serializer().into_inner();
+
+        let output = unsafe { archived_root::<BitArray>(&buffer) };
+        assert_eq!(&original[..11], &output[..11]);
+
+        let deserialized: BitArray = output.deserialize(&mut Infallible).unwrap();
+        assert_eq!(&deserialized[..11], &original[..11]);
+    }
+}

--- a/rkyv/src/impls/hashbrown/hash_map.rs
+++ b/rkyv/src/impls/hashbrown/hash_map.rs
@@ -82,6 +82,8 @@ mod tests {
         Deserialize, Infallible,
     };
     use hashbrown::HashMap;
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    use alloc::string::String;
 
     #[test]
     fn index_map() {

--- a/rkyv/src/impls/hashbrown/hash_set.rs
+++ b/rkyv/src/impls/hashbrown/hash_set.rs
@@ -81,6 +81,8 @@ mod tests {
         Deserialize, Infallible,
     };
     use hashbrown::HashSet;
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    use alloc::string::String;
 
     #[test]
     fn index_set() {

--- a/rkyv/src/impls/mod.rs
+++ b/rkyv/src/impls/mod.rs
@@ -13,6 +13,8 @@ mod std;
 // implementations should be moved into their respective crates over time. Before adding support for
 // another crate, please consider getting rkyv support in the crate instead.
 
+#[cfg(feature = "bitvec")]
+mod bitvec;
 #[cfg(feature = "hashbrown")]
 mod hashbrown;
 #[cfg(feature = "indexmap")]

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -141,6 +141,8 @@ extern crate std;
 #[macro_use]
 pub mod macros;
 
+#[cfg(feature = "bitvec")]
+pub mod bitvec;
 pub mod boxed;
 pub mod collections;
 #[cfg(feature = "copy")]

--- a/rkyv/src/util/aligned_vec.rs
+++ b/rkyv/src/util/aligned_vec.rs
@@ -375,7 +375,7 @@ impl AlignedVec {
         if new_len > self.len {
             let additional = new_len - self.len;
             self.reserve(additional);
-            unsafe { std::ptr::write_bytes(self.ptr.as_ptr().add(self.len), value, additional); }
+            unsafe { core::ptr::write_bytes(self.ptr.as_ptr().add(self.len), value, additional); }
         }
         unsafe { self.set_len(new_len); }
     }

--- a/rkyv/src/util/mod.rs
+++ b/rkyv/src/util/mod.rs
@@ -17,9 +17,9 @@ mod scratch_vec;
 use crate::{
     de::deserializers::SharedDeserializeMap,
     ser::{serializers::AllocSerializer, Serializer},
-    Deserialize, Fallible, Serialize,
+    Fallible,
 };
-use crate::{Archive, ArchiveUnsized, RelPtr};
+use crate::{Archive, ArchiveUnsized, RelPtr, Deserialize, Serialize};
 use core::{
     mem,
     ops::{Deref, DerefMut},


### PR DESCRIPTION
This PR adds BitVec support to rkyv.

> bitvec provides a foundational API for bitfields in Rust. It specializes standard-library data structures (slices, arrays, and vectors of bool) to use one-bit-per-bool storage, similar to [std::bitset](https://en.cppreference.com/w/cpp/utility/bitset) and [std::vector](https://en.cppreference.com/w/cpp/container/vector_bool) in C++.

I modified https://github.com/rkyv/rkyv_contrib/pull/3 to directly implement `Archive` on `BitVec` instead of creating a wrapper type. While I was at it, I implemented it for the BitArray type too. Here are a few notes:

- `BitVec<T, O>` now archives to `ArchivedBitVec<Archived<T>, O>` as opposed to https://github.com/rkyv/rkyv_contrib/pull/3 where it would archive to `ArchivedBitVec<T, O>` while using internally an `ArchivedVec<Archived<T>>`, which I think was incorrect behavior.

- `BitArray` doesn't store the bit length because const generics are not stable yet, as explained in the [bitvec docs](https://docs.rs/bitvec/1.0.1/bitvec/array/struct.BitArray.html). This means that an archived `BitArray<usize, O>` will not be equal to a `BitArray<usize, O>` if the `size_XX` cargo feature doesn't match the target's pointer width. This can be a big footgun so maybe removing the `ArchivedBitArray` implementation is the best decision until const generics are available.

- I think implementing `BitBox` would require adding a bitvec feature to the ptr_meta crate. Indeed, we need to store an unsized `BitSlice` in `ArchivedBox`. The [BitSpan docs](https://github.com/bitvecto-rs/bitvec/blob/main/doc/ptr/BitSpan.md), states that the `Pointee` trait could be defined as `(usize, BitIdx<T::Mem>)`. However I don't think it's really important to support it as 99% of the people will be only using `ArchivedBitVec` anyway.

