### PR TITLE
Add riscv32im

### DIFF
--- a/rkyv/build.rs
+++ b/rkyv/build.rs
@@ -22,7 +22,7 @@ fn main() {
         // 64-bit atomics. (`armv7`, `armv7a`, and `armv7s`, specifically)
         "armv5te" | "mips" | "mipsel" | "powerpc" | "riscv32imac" | "thumbv7em" | "thumbv7m"
         | "thumbv8m.base" | "thumbv8m.main" | "armebv7r" | "armv7r" => has_atomic64 = false,
-        "avr" | "riscv32i" | "riscv32imc" | "thumbv6m" => {
+        "avr" | "riscv32i" | "riscv32im" | "riscv32imc" | "thumbv6m" => {
             has_atomic32 = false;
             has_atomic64 = false;
         }


### PR DESCRIPTION
The project I'm using uses riscv32im instruction set that also doesn't support atomic32/64. Since i vs im vs imc is just differences with extensions added to the standard riscv32, it probably make sense to include them under a single matcher but this works for now