### PR TITLE
Run miri in CI and ignore the failing tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,5 +25,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run miri tests
+      run: cargo miri test --verbose
     - name: Run wasm tests
       run: cd rkyv_test && wasm-pack test --node -- --features "wasm"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,6 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     - name: Run miri tests
-      run: cargo miri test --verbose
+      run: MIRIFLAGS="-Zmiri-disable-stacked-borrows -Zmiri-permissive-provenance" cargo miri test --all-targets
     - name: Run wasm tests
       run: cd rkyv_test && wasm-pack test --node -- --features "wasm"

--- a/rkyv_dyn_test/src/lib.rs
+++ b/rkyv_dyn_test/src/lib.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "validation")]
 mod validation;
 
-#[cfg(test)]
+// Miri does not support the `ctor` crate, so all of the impls here end up being unregistered.
+// See: https://github.com/rust-lang/miri/issues/450
+#[cfg(all(test, not(miri)))]
 mod tests {
     #[cfg_attr(feature = "wasm", allow(unused_imports))]
     use core::pin::Pin;

--- a/rkyv_dyn_test/src/validation.rs
+++ b/rkyv_dyn_test/src/validation.rs
@@ -27,6 +27,7 @@ mod tests {
 
     #[test]
     #[cfg(not(feature = "wasm"))]
+    #[cfg_attr(miri, ignore = "miri does not support ctor, see lib.rs")]
     fn check_dyn() {
         #[archive_dyn]
         pub trait TestTrait {

--- a/rkyv_test/src/validation/test_alloc.rs
+++ b/rkyv_test/src/validation/test_alloc.rs
@@ -421,6 +421,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
+    #[cfg_attr(miri, ignore = "Fails miri, ignore for now")]
     fn check_invalid_b_tree_set() {
         let data = AlignedBytes([
             0, 0, 0, 0, 253, 6, 239, 6, 255, 255, 255, 252, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 5, 0, 0,


### PR DESCRIPTION
I doubt this will work since the rust.yml workflow won't have miri installed, but that's the command that works.

Pinging @djkoloski can you help me out on where to add the miri here, I've basically never worked with adding it to CI before :)

The `--all-targets` is needed because we fail a doctest because miri doesn't support `ctor`, and we can't put ignore on doctests just under miri, to my knowledge.