### PR TITLE
Unify documentation of `out_field!` with its uses

### DIFF
--- a/rkyv/src/macros.rs
+++ b/rkyv/src/macros.rs
@@ -10,14 +10,24 @@ macro_rules! default {
     ($($fn:tt)*) => { $($fn)* };
 }
 
-/// Returns a tuple of the field offset and a mutable pointer to the field of the given struct
-/// pointer.
-///
-/// # Examples
+/// Returns a tuple of `(field_pos, field_out)`, where `field_pos` is the "position",
+/// i.e. offset in bytes, of the field relative to the base address of the struct and `field_out`
+/// is a `*mut` that points to the field directly.
+/// 
+/// This is essentially a convenience wrapper around [`core::ptr::addr_of_mut!`] that also
+/// gives back the relative offset of the field, as these are often needed together. You will often
+/// see the return values named `(fp, fo)` in internal use of this macro, which stand for `field_pos`
+/// and `field_out` respectively as discussed above.
+/// 
+/// # Example
+/// 
 /// ```
 /// use core::mem::MaybeUninit;
 /// use rkyv::out_field;
 ///
+/// // The macro works on repr(Rust) structs as well, but for the purposes of asserting
+/// // an exact guaranteed position of each field in this example, we'll use repr(C)
+/// #[repr(C)]
 /// struct Example {
 ///     a: i32,
 ///     b: bool,
@@ -26,10 +36,13 @@ macro_rules! default {
 /// let mut result = MaybeUninit::<Example>::zeroed();
 /// let out = result.as_mut_ptr();
 ///
-/// let (a_off, a) = out_field!(out.a);
-/// unsafe { a.write(42); }
-/// let (b_off, b) = out_field!(out.b);
-/// unsafe { b.write(true); }
+/// let (a_pos, a_out) = out_field!(out.a);
+/// assert_eq!(a_pos, 0); // guaranteed by repr(C) layout, repr(Rust) has free reign
+/// unsafe { a_out.write(42); }
+/// 
+/// let (b_pos, b_out) = out_field!(out.b);
+/// assert_eq!(b_pos, 4); // guaranteed by repr(C) layout, repr(Rust) has free reign
+/// unsafe { b_out.write(true); }
 ///
 /// let result = unsafe { result.assume_init() };
 /// assert_eq!(result.a, 42);


### PR DESCRIPTION
Fixes #254 by rewording the documentation and example of `out_field!`. Also, changes the naming of the return tuple in the documentation of `Archive` to be more verbose so it's a little less confusing for the uninitiated.