### PR TITLE
Add `from_raw_parts` style interfaces to `RelPtr` and `ArchivedBox`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ book
 Cargo.lock
 /target
 /.vscode
+/tmp

--- a/rkyv/src/boxed.rs
+++ b/rkyv/src/boxed.rs
@@ -58,6 +58,25 @@ impl<T: ArchivePointee + ?Sized> ArchivedBox<T> {
         })
     }
 
+    /// Resolves an archived box from a [`BoxResolver`] which contains
+    /// the raw [`<T as ArchivePointee>::ArchivedMetadata`] directly.
+    ///
+    /// # Safety
+    ///
+    /// - `pos` must be the position of `out` within the archive
+    /// - `resolver` must be obtained by following the safety documentation of
+    /// [`BoxResolver::from_raw_parts`].
+    /// 
+    /// [`<T as ArchivePointee>::ArchivedMetadata`]: ArchivePointee::ArchivedMetadata
+    pub unsafe fn resolve_from_raw_parts(
+        pos: usize,
+        resolver: BoxResolver<<T as ArchivePointee>::ArchivedMetadata>,
+        out: *mut Self,
+    ) {
+        let (fp, fo) = out_field!(out.0);
+        RelPtr::resolve_emplace_from_raw_parts(pos + fp, resolver.pos, resolver.metadata_resolver, fo);
+    }
+
     #[doc(hidden)]
     #[inline]
     pub fn is_null(&self) -> bool {
@@ -190,9 +209,39 @@ impl<T: ArchivePointee + ?Sized> fmt::Pointer for ArchivedBox<T> {
 }
 
 /// The resolver for `Box`.
-pub struct BoxResolver<T> {
+pub struct BoxResolver<M> {
     pos: usize,
-    metadata_resolver: T,
+    metadata_resolver: M,
+}
+
+impl<M> BoxResolver<M> {
+    /// Createa a new [`BoxResolver<M>`] from raw parts. Note that `M` here is ***not*** the same
+    /// `T` which should be serialized/contained in the resulting [`ArchivedBox<T>`], and is rather
+    /// a type that can be used to resolve any needed [`ArchivePointee::ArchivedMetadata`]
+    /// for the serialized pointed-to value.
+    /// 
+    /// In most cases, you won't need to create a [`BoxResolver`] yourself and can instead obtain it through
+    /// [`ArchivedBox::serialize_from_ref`] or [`ArchivedBox::serialize_copy_from_slice`].
+    /// 
+    /// # Safety
+    /// 
+    /// Constructing a valid resolver is quite fraught. Please make sure you understand what the implications are before doing it.
+    /// 
+    /// - `pos`: You must ensure that you serialized and resolved (i.e. [`Serializer::serialize_value`])
+    /// a `T` which will be pointed to by the final [`ArchivedBox<T>`] that this resolver will help resolve
+    /// at the given `pos` within the archive.
+    /// 
+    /// - `metadata_resolver`: You must also ensure that the given `metadata_resolver` can be used to successfully produce
+    /// valid [`<T as ArchivePointee>::ArchivedMetadata`] for that serialized `T`. This means it must either be:
+    ///     - The necessary [`<T as ArchivePointee>::ArchivedMetadata`] itself, in which case you may use the created
+    /// [`BoxResolver<<T as ArchivePointee>::ArchivedMetadta>`] as a resolver in [`ArchivedBox::resolve_from_raw_parts`]
+    ///     - An [`ArchiveUnsized::MetadataResolver`] obtained from some `value: &U` where `U: ArchiveUnsized<Archived = T>`, in which case you
+    /// must pass that same `value: &U` into [`ArchivedBox::resolve_from_ref`] along with this [`BoxResolver`].
+    /// 
+    /// [`<T as ArchivePointee>::ArchivedMetadata`]: ArchivePointee::ArchivedMetadata
+    pub unsafe fn from_raw_parts(pos: usize, metadata_resolver: M) -> Self {
+        Self { pos, metadata_resolver }
+    }
 }
 
 #[cfg(feature = "validation")]


### PR DESCRIPTION
Discussed the need for this on Discord. Draft for now so I can prototype with it in `protoss` and make sure it works as expected/is necessary.

Also snuck in a ignore `/tmp` directory in `.gitignore`, a moderately common pattern which I use is to have `rust-analyzer` compile into a separate target directory so that it doesn't conflict with regular cargo builds.