### PR TITLE
Add support for LayoutError propagation

### DIFF
--- a/rkyv/src/validation/mod.rs
+++ b/rkyv/src/validation/mod.rs
@@ -12,7 +12,7 @@ use std::error::Error;
 
 // Replace this trait with core::mem::{align_of_val_raw, size_of_val_raw} when they get stabilized.
 
-/// Gets the layout of a type from its pointer.
+/// Gets the layout of a type from its pointee type and metadata.
 pub trait LayoutRaw
 where
     Self: Pointee,

--- a/rkyv/src/validation/validators/archive.rs
+++ b/rkyv/src/validation/validators/archive.rs
@@ -1,7 +1,11 @@
 //! The provided implementation for `ArchiveContext`.
 
 use crate::{validation::ArchiveContext, Fallible};
-use core::{alloc::Layout, fmt, ops::Range};
+use core::{
+    alloc::{Layout, LayoutError},
+    fmt,
+    ops::Range,
+};
 
 /// Errors that can occur when checking archive memory.
 #[derive(Debug)]
@@ -80,6 +84,11 @@ pub enum ArchiveError {
         /// The maximum depth that subtrees may be validated down to
         max_subtree_depth: usize,
     },
+    /// A layout error occurred
+    LayoutError {
+        /// A layout error
+        layout_error: LayoutError,
+    },
 }
 
 // SAFETY: ArchiveError is safe to send to another thread
@@ -155,6 +164,9 @@ impl fmt::Display for ArchiveError {
                 "pushed a subtree range that exceeded the maximum subtree depth of {}",
                 max_subtree_depth
             ),
+            ArchiveError::LayoutError { layout_error } => {
+                write!(f, "a layout error occurred: {}", layout_error)
+            }
         }
     }
 }
@@ -414,5 +426,9 @@ impl<'a> ArchiveContext for ArchiveValidator<'a> {
         } else {
             Ok(())
         }
+    }
+
+    fn wrap_layout_error(layout_error: core::alloc::LayoutError) -> Self::Error {
+        ArchiveError::LayoutError { layout_error }
     }
 }

--- a/rkyv/src/validation/validators/mod.rs
+++ b/rkyv/src/validation/validators/mod.rs
@@ -13,7 +13,11 @@ use crate::{
 };
 pub use archive::*;
 use bytecheck::CheckBytes;
-use core::{alloc::Layout, any::TypeId, fmt};
+use core::{
+    alloc::{Layout, LayoutError},
+    any::TypeId,
+    fmt,
+};
 pub use shared::*;
 pub use util::*;
 
@@ -149,6 +153,11 @@ impl<'a> ArchiveContext for DefaultValidator<'a> {
         self.archive
             .finish()
             .map_err(DefaultValidatorError::ArchiveError)
+    }
+
+    #[inline]
+    fn wrap_layout_error(error: LayoutError) -> Self::Error {
+        DefaultValidatorError::ArchiveError(ArchiveValidator::wrap_layout_error(error))
     }
 }
 

--- a/rkyv_dyn/src/validation.rs
+++ b/rkyv_dyn/src/validation.rs
@@ -264,6 +264,9 @@ impl ArchiveContext for (dyn DynContext + '_) {
         self.pop_suffix_range_dyn(range)
     }
 
+    fn wrap_layout_error(layout_error: core::alloc::LayoutError) -> Self::Error {
+        Box::new(layout_error) as Box<dyn Error>
+    }
     fn finish(&mut self) -> Result<(), Self::Error> {
         self.finish_dyn()
     }

--- a/rkyv_dyn_derive/src/lib.rs
+++ b/rkyv_dyn_derive/src/lib.rs
@@ -301,8 +301,7 @@ pub fn archive_dyn(
                 use rkyv_dyn::validation::{CHECK_BYTES_REGISTRY, CheckDynError, DynContext};
 
                 impl<#generic_params> LayoutRaw for (dyn #deserialize_trait<#generic_args> + '_) {
-                    fn layout_raw(value: *const Self) -> Result<Layout, LayoutError> {
-                        let metadata = ptr_meta::metadata(value);
+                    fn layout_raw(metadata: <Self as ptr_meta::Pointee>::Metadata) -> Result<Layout, LayoutError> {
                         Ok(metadata.layout())
                     }
                 }

--- a/rkyv_dyn_derive/src/lib.rs
+++ b/rkyv_dyn_derive/src/lib.rs
@@ -191,7 +191,7 @@ pub fn archive_dyn(
                     #input
 
                     const _: () = {
-                        use core::alloc::Layout;
+                        use core::alloc::{Layout, LayoutError};
                         use rkyv::{
                             Archived,
                             Deserialize,
@@ -301,9 +301,9 @@ pub fn archive_dyn(
                 use rkyv_dyn::validation::{CHECK_BYTES_REGISTRY, CheckDynError, DynContext};
 
                 impl<#generic_params> LayoutRaw for (dyn #deserialize_trait<#generic_args> + '_) {
-                    fn layout_raw(value: *const Self) -> Layout {
+                    fn layout_raw(value: *const Self) -> Result<Layout, LayoutError> {
                         let metadata = ptr_meta::metadata(value);
-                        metadata.layout()
+                        Ok(metadata.layout())
                     }
                 }
 
@@ -345,7 +345,7 @@ pub fn archive_dyn(
                 #deserialize_trait_def
 
                 const _: ()  = {
-                    use core::alloc::Layout;
+                    use core::alloc::{Layout, LayoutError};
                     use rkyv::{
                         ser::{ScratchSpace, Serializer},
                         Archive,


### PR DESCRIPTION
Add support for LayoutError propagation.
Add a LayoutError variant to ArchiveError to encapsulate low level LayoutError.
Removes unwrap() and addresses issue #326.
