### PR TITLE
reexport `bytecheck::CheckBytes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 ```rust
 use rkyv::{Archive, Deserialize, Serialize};
 // bytecheck can be used to validate your data if you want
-use bytecheck::CheckBytes;
+use rkyv::CheckBytes;
 
 #[derive(Archive, Deserialize, Serialize, Debug, PartialEq)]
 // This will generate a PartialEq impl between our unarchived and archived types

--- a/book_src/validation.md
+++ b/book_src/validation.md
@@ -9,8 +9,7 @@ To validate an archive, you first have to derive
 type:
 
 ```rs
-use bytecheck::CheckBytes;
-use rkyv::{Archive, Deserialize, Serialize};
+use rkyv::{Archive, CheckBytes, Deserialize, Serialize};
 
 #[derive(Archive, Deserialize, Serialize)]
 #[archive_attr(derive(CheckBytes))]

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -172,6 +172,9 @@ pub mod with;
 #[cfg(feature = "rend")]
 pub use rend;
 
+#[cfg(feature = "validation")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "validation")))]
+pub use bytecheck::CheckBytes;
 use core::alloc::Layout;
 use ptr_meta::Pointee;
 pub use rkyv_derive::{Archive, Deserialize, Serialize};

--- a/rkyv/src/validation/mod.rs
+++ b/rkyv/src/validation/mod.rs
@@ -3,8 +3,7 @@
 pub mod owned;
 pub mod validators;
 
-use crate::{Archive, ArchivePointee, Fallible, RelPtr};
-use bytecheck::CheckBytes;
+use crate::{Archive, ArchivePointee, CheckBytes, Fallible, RelPtr};
 use core::{alloc::Layout, alloc::LayoutError, any::TypeId, fmt};
 use ptr_meta::Pointee;
 #[cfg(feature = "std")]


### PR DESCRIPTION
Re-export `CheckBytes` to allow self-contained  `rkyv/validation` feature flag.

This will benefit downstream crates with `rkyv` feature flags,
 example: https://github.com/chronotope/chrono/pull/959

* avoids having the downstream crate from maintaining their own versioning of `bytecheck` 
* simplifies conditional feature flagging