### PR TITLE
added `workspace.package` values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,18 @@ default-members = [
     "rkyv_test",
     "rkyv_typename",
 ]
+[workspace.package]
+version = "0.7.40"
+authors = ["David Koloski <djkoloski@gmail.com>"]
+edition = "2021"
+license = "MIT"
+documentation = "https://docs.rs/rkyv"
+repository = "https://github.com/rkyv/rkyv"
+
+[workspace.dependencies]
+bytecheck = "~0.6.8"
+proc-macro2 = "1.0"
+ptr_meta = "~0.1.3"
+quote = "1.0"
+syn = "1.0"
+wasm-bindgen-test = "0.3"

--- a/examples/as_string/Cargo.toml
+++ b/examples/as_string/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "as_string"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rkyv = { version = "0.7", path = "../../rkyv" }
+rkyv = { path = "../../rkyv" }

--- a/examples/backwards_compat/Cargo.toml
+++ b/examples/backwards_compat/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "backwards_compat"
-version = "0.1.0"
-edition = "2018"
 publish = false
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = "~0.6.8"
-rkyv = { version = "0.7", path = "../../rkyv", features = ["validation"] }
+bytecheck.workspace = true
+rkyv = { path = "../../rkyv", features = ["validation"] }

--- a/examples/json/Cargo.toml
+++ b/examples/json/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "rkyv_json_example"
-version = "0.0.0"
-edition = "2018"
 publish = false
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = "0.6"
-rkyv = { version = "0.7", path = "../../rkyv", features = ["validation"] }
+bytecheck.workspace = true
+rkyv = { path = "../../rkyv", features = ["validation"] }

--- a/examples/opcode/Cargo.toml
+++ b/examples/opcode/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "opcode"
-version = "0.1.0"
-edition = "2018"
 publish = false
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rkyv = { version = "0.7", path = "../../rkyv" }
+rkyv = { path = "../../rkyv" }

--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -1,24 +1,23 @@
 [package]
 name = "rkyv"
-version = "0.7.40"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
 description = "Zero-copy deserialization framework for Rust"
-license = "MIT"
-documentation = "https://docs.rs/rkyv"
-repository = "https://github.com/rkyv/rkyv"
 keywords = ["archive", "rkyv", "serialization", "zero-copy", "no_std"]
 categories = ["encoding", "no-std"]
 readme = "crates-io.md"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = { version = "~0.6.8", optional = true, default-features = false }
+bytecheck = { workspace = true, optional = true, default-features = false }
 hashbrown = { version = "0.12", optional = true }
-ptr_meta = { version = "~0.1.3", default-features = false }
+ptr_meta = { workspace = true, default-features = false }
 rend = { version = "0.4", optional = true, default-features = false }
-rkyv_derive = { version = "=0.7.40", path = "../rkyv_derive" }
+rkyv_derive = { path = "../rkyv_derive" }
 seahash = "4.0"
 
 # Support for various common crates. These are primarily to get users off the ground and build some

--- a/rkyv/src/validation/mod.rs
+++ b/rkyv/src/validation/mod.rs
@@ -69,7 +69,7 @@ pub trait ArchiveContext: Fallible {
     ///
     /// # Safety
     ///
-    /// - `base` must be inside the archive this valiator was created for.
+    /// - `base` must be inside the archive this validator was created for.
     unsafe fn bounds_check_ptr(
         &mut self,
         base: *const u8,

--- a/rkyv_bench/Cargo.toml
+++ b/rkyv_bench/Cargo.toml
@@ -1,19 +1,21 @@
 [package]
 name = "rkyv_bench"
-version = "0.7.0"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 bincode = "1.3"
-bytecheck = "0.6"
+bytecheck.workspace = true
 criterion = "0.3"
 rand = "0.8"
 rand_pcg = "0.3"
-rkyv = { version = "0.7", path = "../rkyv", default-features = false, features = ["validation"] }
-rkyv_derive = { version = "0.7", path = "../rkyv_derive" }
+rkyv = { path = "../rkyv", default-features = false, features = ["validation"] }
+rkyv_derive = { path = "../rkyv_derive" }
 serde = { version = "1.0", features = ["derive"] }
 
 [features]

--- a/rkyv_derive/Cargo.toml
+++ b/rkyv_derive/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "rkyv_derive"
-version = "0.7.40"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
 description = "Derive macro for rkyv"
-license = "MIT"
-documentation = "https://docs.rs/rkyv_derive"
-repository = "https://github.com/rkyv/rkyv"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,9 +13,9 @@ repository = "https://github.com/rkyv/rkyv"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-syn = "1.0"
-quote = "1.0"
+proc-macro2.workspace = true
+syn.workspace = true
+quote.workspace = true
 
 [features]
 default = []

--- a/rkyv_dyn/Cargo.toml
+++ b/rkyv_dyn/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = { workspace = true, optional = true, default-features = false }
+bytecheck = { workspace = true, optional = true }
 inventory = "0.1"
 lazy_static = "1.4"
 ptr_meta.workspace = true

--- a/rkyv_dyn/Cargo.toml
+++ b/rkyv_dyn/Cargo.toml
@@ -1,26 +1,25 @@
 [package]
 name = "rkyv_dyn"
-version = "0.7.40"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
 description = "Trait object support for rkyv"
-license = "MIT"
-documentation = "https://docs.rs/rkyv_dyn"
-repository = "https://github.com/rkyv/rkyv"
 keywords = ["archive", "rkyv", "serialization", "zero-copy", "no_std"]
 categories = ["encoding", "no-std"]
 readme = "crates-io.md"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = { version = "~0.6.8", optional = true }
+bytecheck = { workspace = true, optional = true, default-features = false }
 inventory = "0.1"
 lazy_static = "1.4"
-ptr_meta = "~0.1.3"
-rkyv = { version = "0.7", path = "../rkyv", default-features = false }
-rkyv_dyn_derive = { version = "=0.7.40", path = "../rkyv_dyn_derive" }
-rkyv_typename = { version = "0.7", path = "../rkyv_typename" }
+ptr_meta.workspace = true
+rkyv = { path = "../rkyv", default-features = false }
+rkyv_dyn_derive = { path = "../rkyv_dyn_derive" }
+rkyv_typename = { path = "../rkyv_typename" }
 
 [features]
 default = ["rkyv/size_32", "rkyv/std"]

--- a/rkyv_dyn/src/validation.rs
+++ b/rkyv_dyn/src/validation.rs
@@ -28,7 +28,7 @@ pub trait DynContext {
     ///
     /// # Safety
     ///
-    /// - `base` must be inside the archive this valiator was created for.
+    /// - `base` must be inside the archive this validator was created for.
     ///
     /// [`bounds_check_ptr`]: rkyv::validation::ArchiveContext::bounds_check_ptr
     unsafe fn bounds_check_ptr_dyn(

--- a/rkyv_dyn_derive/Cargo.toml
+++ b/rkyv_dyn_derive/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "rkyv_dyn_derive"
-version = "0.7.40"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
 description = "Macros for rkyv_dyn"
-license = "MIT"
-documentation = "https://docs.rs/rkyv_dyn_derive"
-repository = "https://github.com/rkyv/rkyv"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,9 +13,9 @@ repository = "https://github.com/rkyv/rkyv"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-syn = { version = "1.0", features = ["full"] }
-quote = "1.0"
+proc-macro2.workspace = true
+syn = { workspace = true, features = ["full"] }
+quote.workspace = true
 
 [features]
 default = []

--- a/rkyv_dyn_test/Cargo.toml
+++ b/rkyv_dyn_test/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 bytecheck = { workspace = true, optional = true }
-ptr_meta.worspace = true
+ptr_meta.workspace = true
 rkyv = { path = "../rkyv", default-features = false }
 rkyv_dyn = { path = "../rkyv_dyn", default-features = false }
 rkyv_typename = { path = "../rkyv_typename", default-features = false }

--- a/rkyv_dyn_test/Cargo.toml
+++ b/rkyv_dyn_test/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "rkyv_dyn_test"
-version = "0.7.0"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
 description = "Test suit for rkyv_dyn"
-license = "MIT"
-repository = "https://github.com/rkyv/rkyv"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = { version = "0.6", optional = true }
-ptr_meta = "~0.1.3"
+bytecheck = { workspace = true, optional = true }
+ptr_meta.worspace = true
 rkyv = { path = "../rkyv", default-features = false }
 rkyv_dyn = { path = "../rkyv_dyn", default-features = false }
 rkyv_typename = { path = "../rkyv_typename", default-features = false }
-wasm-bindgen-test = { version = "0.3", optional = true }
+wasm-bindgen-test = { workspace = true, optional = true }
 
 [features]
 default = ["rkyv/size_32", "rkyv/std", "validation"]

--- a/rkyv_test/Cargo.toml
+++ b/rkyv_test/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "rkyv_test"
-version = "0.7.1"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
 description = "Test suite for rkyv crates"
-license = "MIT"
-repository = "https://github.com/rkyv/rkyv"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = { version = "0.6", optional = true, default-features = false }
-ptr_meta = { version = "~0.1.3", default-features = false }
+bytecheck = { workspace = true, optional = true, default-features = false }
+ptr_meta = { workspace = true, default-features = false }
 rkyv = { path = "../rkyv", default-features = false }
-wasm-bindgen-test = { version = "0.3", optional = true }
+wasm-bindgen-test = { workspace = true, optional = true }
 ahash = { version = "0.7" }
 
 [features]

--- a/rkyv_test/Cargo.toml
+++ b/rkyv_test/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "rkyv_test"
 description = "Test suite for rkyv crates"
-version.workspace = true
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
-repository.workspace = true
+version = "0.7.40"
+authors = ["David Koloski <djkoloski@gmail.com>"]
+edition = "2021"
+license = "MIT"
+documentation = "https://docs.rs/rkyv"
+repository = "https://github.com/rkyv/rkyv"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rkyv_typename/Cargo.toml
+++ b/rkyv_typename/Cargo.toml
@@ -1,20 +1,19 @@
 [package]
 name = "rkyv_typename"
 version = "0.7.33"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
 description = "Customizable naming for types"
-license = "MIT"
-documentation = "https://docs.rs/rkyv_typename"
-repository = "https://github.com/rkyv/rkyv"
 keywords = ["archive", "rkyv", "serialization", "zero-copy", "no_std"]
 categories = ["encoding", "no-std"]
 readme = "crates-io.md"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rkyv_typename_derive = { version = "=0.7.33", path = "../rkyv_typename_derive" }
+rkyv_typename_derive = { path = "../rkyv_typename_derive" }
 
 [features]
 default = ["std"]

--- a/rkyv_typename_derive/Cargo.toml
+++ b/rkyv_typename_derive/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "rkyv_typename_derive"
 version = "0.7.33"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
 description = "Derive macro for rkyv_typename"
-license = "MIT"
-documentation = "https://docs.rs/rkyv_typename_derive"
-repository = "https://github.com/rkyv/rkyv"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,9 +13,9 @@ repository = "https://github.com/rkyv/rkyv"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-syn = "1.0"
-quote = "1.0"
+proc-macro2.workspace = true
+syn.workspace = true
+quote.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Similar work to https://github.com/rkyv/bytecheck/pull/28

Converted repo to use [`workspace.package` feature](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table)