### PR TITLE
set `bytecheck` crate root when using reexported derive macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ documentation = "https://docs.rs/rkyv"
 repository = "https://github.com/rkyv/rkyv"
 
 [workspace.dependencies]
-bytecheck = "~0.6.8"
+bytecheck = "0.6.10"
 proc-macro2 = "1.0"
 ptr_meta = "~0.1.3"
 quote = "1.0"

--- a/book_src/validation.md
+++ b/book_src/validation.md
@@ -9,10 +9,10 @@ To validate an archive, you first have to derive
 type:
 
 ```rs
-use rkyv::{Archive, CheckBytes, Deserialize, Serialize};
+use rkyv::{Archive, Deserialize, Serialize};
 
 #[derive(Archive, Deserialize, Serialize)]
-#[archive_attr(derive(CheckBytes))]
+#[archive(check_bytes)]
 pub struct Example {
     a: i32,
     b: String,
@@ -20,8 +20,7 @@ pub struct Example {
 }
 ```
 
-The `#[archive_attr(...)]` attribute applies the provided attributes to the archived type. Finally,
-you can use
+The `#[archive(check_bytes)]` attribute derives `CheckBytes` on the archived type. Finally, you can use
 [`check_archived_root`](https://docs.rs/rkyv/0.7.1/rkyv/validation/validators/fn.check_archived_root.html) to
 check an archive and get a reference to the archived value if it was successful:
 

--- a/examples/backwards_compat/Cargo.toml
+++ b/examples/backwards_compat/Cargo.toml
@@ -10,5 +10,4 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck.workspace = true
 rkyv = { path = "../../rkyv", features = ["validation"] }

--- a/examples/backwards_compat/src/main.rs
+++ b/examples/backwards_compat/src/main.rs
@@ -1,10 +1,10 @@
-use bytecheck::CheckBytes;
 use rkyv::{with::AsBox, Archive, Deserialize, Serialize};
 
 // This is the version used by the older client, which can read newer versions
 // from senders.
 #[derive(Archive, Deserialize, Serialize)]
-#[archive_attr(repr(C), derive(CheckBytes))]
+#[archive(check_bytes)]
+#[archive_attr(repr(C))]
 struct ExampleV1 {
     a: i32,
     b: u32,
@@ -13,7 +13,8 @@ struct ExampleV1 {
 // This is the version used by the newer client, which can send newer versions
 // to receivers.
 #[derive(Archive, Deserialize, Serialize)]
-#[archive_attr(repr(C), derive(CheckBytes))]
+#[archive(check_bytes)]
+#[archive_attr(repr(C))]
 struct ExampleV2 {
     a: i32,
     b: i32,
@@ -28,7 +29,8 @@ struct ExampleV2 {
 // buffer.
 #[derive(Archive, Deserialize, Serialize)]
 #[repr(transparent)]
-#[archive_attr(repr(transparent), derive(CheckBytes))]
+#[archive(check_bytes)]
+#[archive_attr(repr(transparent))]
 struct Versioned<T>(#[with(AsBox)] pub T);
 
 // This is some code running on the older client. It accepts the older version

--- a/examples/json/Cargo.toml
+++ b/examples/json/Cargo.toml
@@ -10,5 +10,4 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck.workspace = true
 rkyv = { path = "../../rkyv", features = ["validation"] }

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -1,4 +1,3 @@
-use bytecheck::CheckBytes;
 use rkyv::{
     check_archived_root,
     ser::{serializers::AllocSerializer, Serializer},
@@ -33,7 +32,7 @@ use std::{collections::HashMap, fmt};
 //
 // To validate our archived type, we also need to derive `CheckBytes` on it. We can use the
 // `#[archive_attr(..)]` attribute to pass any attributes through to the generated type. So to
-// derive `CheckBytes` for our archived type, we simply add `#[archive_attr(derive(CheckBytes))]` to
+// derive `CheckBytes` for our archived type, we simply add `#[archive(check_bytes)]` to
 // our type.
 //
 // This has the same issues as our `Archive` derive, so we need to follow a similar process:
@@ -55,12 +54,10 @@ use std::{collections::HashMap, fmt};
 // `Box<dyn Error>`.
 //
 // With those two changes, our recursive type can be validated with `check_archived_root`!
-#[archive_attr(
-    derive(CheckBytes),
-    check_bytes(
-        bound = "__C: rkyv::validation::ArchiveContext, <__C as rkyv::Fallible>::Error: std::error::Error"
-    )
-)]
+#[archive(check_bytes)]
+#[archive_attr(check_bytes(
+    bound = "__C: rkyv::validation::ArchiveContext, <__C as rkyv::Fallible>::Error: std::error::Error"
+))]
 pub enum JsonValue {
     Null,
     Bool(bool),
@@ -111,7 +108,7 @@ impl fmt::Display for ArchivedJsonValue {
 }
 
 #[derive(Archive, Debug, Deserialize, Serialize)]
-#[archive_attr(derive(CheckBytes))]
+#[archive(check_bytes)]
 pub enum JsonNumber {
     PosInt(u64),
     NegInt(i64),

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -174,7 +174,7 @@ pub use rend;
 
 #[cfg(feature = "validation")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "validation")))]
-pub use bytecheck::CheckBytes;
+pub use bytecheck::{self, CheckBytes};
 use core::alloc::Layout;
 use ptr_meta::Pointee;
 pub use rkyv_derive::{Archive, Deserialize, Serialize};

--- a/rkyv_derive/src/lib.rs
+++ b/rkyv_derive/src/lib.rs
@@ -43,6 +43,10 @@ use syn::{parse_macro_input, DeriveInput};
 ///   recursive type definitions. Use `archive = "..."` to specify `Archive` bounds,
 ///   `serialize = "..."` to specify `Serialize` bounds, and `deserialize = "..."` to specify
 ///   `Deserialize` bounds.
+/// - `check_bytes`: Derive `CheckBytes` on the archived type, in order to enable safe
+///   deserialization. Requires `validation` feature. Not compatible with `as = "..."`. In that
+///   case, use `#[derive(CheckBytes)]` on the archived type, and include a `use rkyv::bytecheck`
+///   statement.
 /// - `copy_safe`: States that the archived type is tightly packed with no padding bytes. This
 ///   qualifies it for copy optimizations. (requires nightly)
 /// - `as = "..."`: Instead of generating a separate archived type, this type will archive as the

--- a/rkyv_test/Cargo.toml
+++ b/rkyv_test/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/rkyv/rkyv"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = { workspace = true, optional = true, default-features = false }
 ptr_meta = { workspace = true, default-features = false }
 rkyv = { path = "../rkyv", default-features = false }
 wasm-bindgen-test = { workspace = true, optional = true }
@@ -29,7 +28,7 @@ rend = ["rkyv/rend"]
 size_16 = ["rkyv/size_16"]
 size_32 = ["rkyv/size_32"]
 size_64 = ["rkyv/size_64"]
-std = ["alloc", "bytecheck/std", "rkyv/std"]
+std = ["alloc", "rkyv/std"]
 strict = ["rkyv/strict"]
-validation = ["alloc", "bytecheck", "rkyv/validation"]
+validation = ["alloc", "rkyv/validation"]
 wasm = ["wasm-bindgen-test"]

--- a/rkyv_test/src/test_alloc.rs
+++ b/rkyv_test/src/test_alloc.rs
@@ -106,15 +106,14 @@ mod tests {
         #[allow(unused_variables)]
         #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
         fn archive_example() {
+            // CheckBytes from bytecheck can be used to validate your data, if you want
             use rkyv::{Archive, Deserialize, Serialize};
-            // bytecheck can be used to validate your data if you want
-            use bytecheck::CheckBytes;
 
             #[derive(Archive, Deserialize, Serialize, Debug, PartialEq)]
             // This will generate a PartialEq impl between our unarchived and archived types
-            #[archive(compare(PartialEq))]
             // To use the safe API, you have to derive CheckBytes for the archived type
-            #[archive_attr(derive(CheckBytes, Debug))]
+            #[archive(check_bytes, compare(PartialEq))]
+            #[archive_attr(derive(Debug))]
             struct Test {
                 int: u8,
                 string: String,

--- a/rkyv_test/src/validation/bytecheck_reexport.rs
+++ b/rkyv_test/src/validation/bytecheck_reexport.rs
@@ -1,0 +1,87 @@
+#[cfg(test)]
+mod tests {
+    use rkyv::{Archive, CheckBytes};
+
+    #[derive(Archive)]
+    #[archive_attr(derive(Debug, Default), repr(C))]
+    #[archive(check_bytes)]
+    struct Test {
+        a: u8,
+        b: bool,
+    }
+
+    #[derive(Archive)]
+    #[archive_attr(derive(Debug, Default), check_bytes(bound = "__C: Default"), repr(C))]
+    #[archive(check_bytes)]
+    struct OtherAttr {
+        a: u8,
+        b: bool,
+    }
+
+    #[derive(Archive)]
+    #[archive_attr(
+        derive(CheckBytes, Debug, Default),
+        check_bytes(crate = "rkyv::bytecheck"),
+        repr(C)
+    )]
+    struct ExplicitCrate {
+        a: u8,
+        b: bool,
+    }
+
+    #[derive(Archive)]
+    #[archive(check_bytes)]
+    struct Unit;
+
+    #[derive(Archive)]
+    #[archive(check_bytes)]
+    struct NewType(u8);
+
+    #[derive(Archive)]
+    #[archive(check_bytes)]
+    struct Tuple(u8, bool);
+
+    #[derive(Archive)]
+    #[archive(check_bytes)]
+    #[allow(dead_code)]
+    enum Enum {
+        A(u8),
+        B,
+    }
+
+    mod rkyv_path {
+        // Doesn't hide it from users of `::rkyv`, but tests that we add the
+        // attribute when `rkyv2::CheckBytes` is derived instead of `rkyv::CheckBytes`.
+        mod rkyv {}
+        use ::rkyv as rkyv2;
+        #[derive(rkyv2::Archive)]
+        #[archive(crate = "rkyv2", check_bytes)]
+        struct RkyvPath;
+    }
+
+    #[repr(C, align(16))]
+    struct Aligned<const N: usize>([u8; N]);
+
+    #[test]
+    fn test() {
+        let a = ArchivedTest::default();
+        unsafe {
+            ArchivedTest::check_bytes(&a, &mut ()).unwrap();
+        }
+        unsafe {
+            let a_bytes: *const u8 = &a as *const ArchivedTest as *const u8;
+            let mut bytes = Aligned([*a_bytes.offset(0), *a_bytes.offset(1)]);
+            bytes.0[1] = 5;
+            ArchivedTest::check_bytes(&bytes.0 as *const [u8] as *const ArchivedTest, &mut ())
+                .unwrap_err();
+        }
+
+        // Should throw compile error:
+        //     ArchivedOtherAttr::check_bytes(0 as *const _, &mut NoDefault).unwrap();
+        //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `NoDefault`
+        /* unsafe {
+            struct NoDefault;
+            ArchivedOtherAttr::check_bytes(0 as *const _, &mut NoDefault).unwrap();
+        } */
+    }
+}

--- a/rkyv_test/src/validation/mod.rs
+++ b/rkyv_test/src/validation/mod.rs
@@ -1,3 +1,4 @@
+mod bytecheck_reexport;
 #[cfg(feature = "alloc")]
 mod test_alloc;
 #[cfg(feature = "std")]

--- a/rkyv_test/src/validation/test_alloc.rs
+++ b/rkyv_test/src/validation/test_alloc.rs
@@ -10,10 +10,9 @@ mod tests {
         vec,
         vec::Vec,
     };
-    use bytecheck::CheckBytes;
     use rkyv::{
         check_archived_root, check_archived_value, ser::Serializer, AlignedBytes, Archive,
-        Deserialize, Infallible, Serialize,
+        CheckBytes, Deserialize, Infallible, Serialize,
     };
     #[cfg(feature = "std")]
     use std::{
@@ -213,8 +212,8 @@ mod tests {
     #[test]
     #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn cycle_detection() {
-        use bytecheck::Error;
         use core::fmt;
+        use rkyv::bytecheck::Error;
 
         use rkyv::{validation::ArchiveContext, Archived};
 
@@ -303,7 +302,7 @@ mod tests {
     #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn derive_unit_struct() {
         #[derive(Archive, Serialize)]
-        #[archive_attr(derive(CheckBytes))]
+        #[archive(check_bytes)]
         struct Test;
 
         serialize_and_check(&Test);
@@ -313,7 +312,7 @@ mod tests {
     #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn derive_struct() {
         #[derive(Archive, Serialize)]
-        #[archive_attr(derive(CheckBytes))]
+        #[archive(check_bytes)]
         struct Test {
             a: u32,
             b: String,
@@ -331,7 +330,7 @@ mod tests {
     #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn derive_tuple_struct() {
         #[derive(Archive, Serialize)]
-        #[archive_attr(derive(CheckBytes))]
+        #[archive(check_bytes)]
         struct Test(u32, String, Box<Vec<String>>);
 
         serialize_and_check(&Test(
@@ -345,7 +344,7 @@ mod tests {
     #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn derive_enum() {
         #[derive(Archive, Serialize)]
-        #[archive_attr(derive(CheckBytes))]
+        #[archive(check_bytes)]
         enum Test {
             A(u32),
             B(String),
@@ -367,9 +366,9 @@ mod tests {
         // The derive macros don't apply the right bounds from Box so we have to manually specify
         // what bounds to apply
         #[archive(bound(serialize = "__S: Serializer", deserialize = "__D: Deserializer"))]
-        #[archive_attr(derive(CheckBytes))]
+        #[archive(check_bytes)]
         #[archive_attr(check_bytes(
-            bound = "__C: ::rkyv::validation::ArchiveContext, <__C as ::rkyv::Fallible>::Error: ::bytecheck::Error"
+            bound = "__C: ::rkyv::validation::ArchiveContext, <__C as ::rkyv::Fallible>::Error: ::rkyv::bytecheck::Error"
         ))]
         enum Node {
             Nil,
@@ -387,7 +386,7 @@ mod tests {
     #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn check_shared_ptr() {
         #[derive(Archive, Serialize, Eq, PartialEq)]
-        #[archive_attr(derive(CheckBytes))]
+        #[archive(check_bytes)]
         struct Test {
             a: Rc<u32>,
             b: Rc<u32>,
@@ -478,7 +477,7 @@ mod tests {
     #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn b_tree_struct_member() {
         #[derive(Archive, Serialize, Deserialize, Debug, Default)]
-        #[archive_attr(derive(CheckBytes))]
+        #[archive(check_bytes)]
         pub struct MyType {
             pub some_list: BTreeMap<String, Vec<f32>>,
             pub values: Vec<f32>,

--- a/rkyv_test/src/validation/util.rs
+++ b/rkyv_test/src/validation/util.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "alloc")]
 pub mod alloc {
     use crate::util::alloc::*;
-    use bytecheck::CheckBytes;
     use rkyv::{
-        check_archived_root, ser::Serializer, validation::validators::DefaultValidator, Serialize,
+        check_archived_root, ser::Serializer, validation::validators::DefaultValidator, CheckBytes,
+        Serialize,
     };
 
     pub fn serialize_and_check<T: Serialize<DefaultSerializer>>(value: &T)


### PR DESCRIPTION
Fixes #343 depends on https://github.com/rkyv/bytecheck/pull/30

This reexports bytecheck and adds `#[check_bytes(crate = "::rkyv::bytecheck")]` to derived archive types, when `#[archive_attr(derive(CheckBytes))]` is used.

It does not work for `#[archive(as = "Self")]`, then the user must add this manually. Edit: actually, you can just change your import to `use rkyv::{CheckBytes, bytecheck}`. In fact, doing such an import makes this entire commit unnecessary. I still think it's convenient though?

There is some low potential for conflict for existing users, as it will add this attribute even for those not using the reexported macro, as there is no way (that I know of) to determine that exactly. I can't think of a normal situation where this would cause issues, but this is technically a breaking change. (if someone is deriving a type also called CheckBytes from a crate other than bytecheck, this will break their code)

`bytecheck` is removed as a dependency from `rkyv_test`, in order to test this (and it's no longer necessary to depend on it directly).