### PR TITLE
Add Send + Sync bounds for bytecheck::Error in bytecheck 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ documentation = "https://docs.rs/rkyv"
 repository = "https://github.com/rkyv/rkyv"
 
 [workspace.dependencies]
-bytecheck = "0.6.10"
+bytecheck = "0.7.0"
 proc-macro2 = "1.0"
 ptr_meta = "~0.1.3"
 quote = "1.0"

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -56,7 +56,7 @@ use std::{collections::HashMap, fmt};
 // With those two changes, our recursive type can be validated with `check_archived_root`!
 #[archive(check_bytes)]
 #[archive_attr(check_bytes(
-    bound = "__C: rkyv::validation::ArchiveContext, <__C as rkyv::Fallible>::Error: std::error::Error"
+    bound = "__C: rkyv::validation::ArchiveContext, <__C as rkyv::Fallible>::Error: rkyv::bytecheck::Error"
 ))]
 pub enum JsonValue {
     Null,


### PR DESCRIPTION
Adds send + Sync bounds for bytecheck::Error change in bytecheck 0.7 and updates bytecheck.

Also added a commit to add Send + Sync for rkyv_dyn's boxed errors, as that seems like a reasonable change in the same spirit, and updating bytecheck required making the (extremely minor) breaking change that `CheckDynError` no longer implements `From<Box<dyn Error>>`, only `From<Box<dyn Error + Send + Sync>>`

I guess this should go into the 0.8 branch, but it touches changes that that branch is missing.