### PR TITLE
Fix `AlignedVec::shrink_to_fit` when `len` is 0

### DIFF
--- a/rkyv/src/util/aligned_vec.rs
+++ b/rkyv/src/util/aligned_vec.rs
@@ -189,14 +189,14 @@ impl AlignedVec {
     /// assert_eq!(vec.capacity(), 10);
     /// vec.shrink_to_fit();
     /// assert!(vec.capacity() >= 3);
+    ///
+    /// vec.clear();
+    /// vec.shrink_to_fit();
+    /// assert!(vec.capacity() == 0);
     /// ```
     #[inline]
     pub fn shrink_to_fit(&mut self) {
-        if self.len == 0 {
-            self.clear()
-        } else {
-            self.change_capacity(self.len);
-        }
+        self.change_capacity(self.len);
     }
 
     /// Returns an unsafe mutable pointer to the vector's buffer.


### PR DESCRIPTION
Currently `AlignedVec::shrink_to_fit()` is a no-op if `len` is 0.

```rust
let mut v = AlignedVec::with_capacity(10);
assert_eq!(v.capacity(), 10);
v.shrink_to_fit();
assert_eq!(v.capacity(), 10); // Still 10!
```

This is at odds with `Vec`'s behavior - which shrinks to 0 capacity if len is 0.

[playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=e72d2803546620ecbafc4afd8f780bb7)

This PR fixes that.
