### PR TITLE
`AlignedVec` call `handle_alloc_error` on alloc failure

### DIFF
--- a/rkyv/src/util/aligned_vec.rs
+++ b/rkyv/src/util/aligned_vec.rs
@@ -132,13 +132,15 @@ impl AlignedVec {
                 "`capacity` cannot exceed isize::MAX - 15"
             );
             let ptr = unsafe {
-                alloc::alloc(alloc::Layout::from_size_align_unchecked(
-                    capacity,
-                    Self::ALIGNMENT,
-                ))
+                let layout = alloc::Layout::from_size_align_unchecked(capacity, Self::ALIGNMENT);
+                let ptr = alloc::alloc(layout);
+                if ptr.is_null() {
+                    alloc::handle_alloc_error(layout);
+                }
+                NonNull::new_unchecked(ptr)
             };
             Self {
-                ptr: NonNull::new(ptr).unwrap(),
+                ptr,
                 cap: capacity,
                 len: 0,
             }
@@ -178,12 +180,23 @@ impl AlignedVec {
     #[inline]
     unsafe fn change_capacity(&mut self, new_cap: usize) {
         let new_ptr = if self.cap != 0 {
-            alloc::realloc(self.ptr.as_ptr(), self.layout(), new_cap)
+            let new_ptr = alloc::realloc(self.ptr.as_ptr(), self.layout(), new_cap);
+            if new_ptr.is_null() {
+                alloc::handle_alloc_error(alloc::Layout::from_size_align_unchecked(
+                    new_cap,
+                    Self::ALIGNMENT,
+                ));
+            }
+            new_ptr
         } else {
             let layout = alloc::Layout::from_size_align_unchecked(new_cap, Self::ALIGNMENT);
-            alloc::alloc(layout)
+            let new_ptr = alloc::alloc(layout);
+            if new_ptr.is_null() {
+                alloc::handle_alloc_error(layout);
+            }
+            new_ptr
         };
-        self.ptr = NonNull::new(new_ptr).unwrap();
+        self.ptr = NonNull::new_unchecked(new_ptr);
         self.cap = new_cap;
     }
 


### PR DESCRIPTION
[Rust docs for alloc](https://doc.rust-lang.org/alloc/alloc/trait.GlobalAlloc.html#tymethod.alloc) say:

> Clients wishing to abort computation in response to an allocation error are encouraged to call the [`handle_alloc_error`](https://doc.rust-lang.org/alloc/alloc/fn.handle_alloc_error.html) function, rather than directly invoking `panic!` or similar.

`AlignedVec` currently panics if allocation fails. This PR converts panics to `handle_alloc_error` calls.

Sorry for the flood of PRs!