### PR TITLE
Improve performance of `AlignedVec::reserve`

### DIFF
--- a/rkyv/src/util/aligned_vec.rs
+++ b/rkyv/src/util/aligned_vec.rs
@@ -176,7 +176,8 @@ impl AlignedVec {
     ///
     /// # Safety
     ///
-    /// Caller must ensure `new_cap` is not greater than `Self::MAX_CAPACITY`.
+    /// - `new_cap` must be less than or equal to [`MAX_CAPACITY`](AlignedVec::MAX_CAPACITY)
+    /// - `new_cap` must be greater than or equal to [`len()`](AlignedVec::len)
     #[inline]
     unsafe fn change_capacity(&mut self, new_cap: usize) {
         let new_ptr = if self.cap != 0 {


### PR DESCRIPTION
While doing some experiments, I was wondering why `AlignedVec` was performing significantly slower than `Vec` when you're just writing slices of `u8`s to it.

I think I figured it out, and this PR bring the performance of `AlignedVec::extend_from_slice` up to parity with `Vec`.

The trick is an optimization in `reserve` [which `Vec` uses](https://doc.rust-lang.org/src/alloc/raw_vec.rs.html#274). When the `Vec`/`AlignedVec` is large compared to to the size of chunks you're writing into it, almost always a call to `reserve` is a no-op - there's already sufficient capacity.

The optimization is to split `reserve` into 2 functions. The fast path for just checking capacity is sufficient and returning is marked `#[inline]`. The more complicated logic for actually extending the vec on the rare occasions that it does need to grow is moved into a separate function marked `#[cold]`. My understanding is that this hints that branch prediction should assume the fast path, and makes `reserve` really small, so it can be easily inlined.

(you probably know how this works better than me, just want to document the explanation for this change as I didn't open an issue for it)

On my test which doesn't involve any serialization, just stuffing loads of data into the `AlignedVec`, this change produces a ~20% speed gain.

```
time:   [12.214 µs 12.224 µs 12.236 µs]
change: [-22.747% -22.464% -22.189%] (p = 0.00 < 0.05)
Performance has improved.
```

The effect is less visible when it's mixed in with other activity. But I still get an approx 1-2% speed increase on the serialization benchmark in RKYV repo.