### PR TITLE
Make alloc serializers send again

### DIFF
--- a/rkyv/src/ser/serializers/core.rs
+++ b/rkyv/src/ser/serializers/core.rs
@@ -205,6 +205,8 @@ pub struct BufferScratch<T> {
     ptr: Option<NonNull<[u8]>>,
 }
 
+unsafe impl<T> Send for BufferScratch<T> where T: Send {}
+
 impl<T> BufferScratch<T> {
     /// Creates a new buffer scratch allocator.
     pub fn new(buffer: T) -> Self {


### PR DESCRIPTION
This summer line 205 (at the top. of the patch) made AllocSerializer !Send which makes it very hard to use with async rust. 

By implementing send explicitly this is avoided. As far as I can see it should not be a problem to implement send the way the ptr field is used in the current code. This is confirmed in the comment in the exchange below too.

https://github.com/rkyv/rkyv/commit/359aa4aec662837b0b6731db194172cf819e4838#r102643633