### PR TITLE
Fix Archive macro for enums whos variants clash with associated types

### DIFF
--- a/rkyv_derive/src/archive.rs
+++ b/rkyv_derive/src/archive.rs
@@ -1275,7 +1275,7 @@ fn derive_archive_impl(
                         // Some resolvers will be (), this allow is to prevent clippy from complaining
                         #[allow(clippy::unit_arg)]
                         #[inline]
-                        unsafe fn resolve(&self, pos: usize, resolver: Self::Resolver, out: *mut Self::Archived) {
+                        unsafe fn resolve(&self, pos: usize, resolver: <Self as Archive>::Resolver, out: *mut <Self as Archive>::Archived) {
                             match resolver {
                                 #(#resolve_arms,)*
                             }


### PR DESCRIPTION
This disambiguates associated types in the `Archive` derive macro for enums so that the macro no longer errors for variants called `Archived` or `Resolver`, e.g.
```rs
#[derive(Archive)]
struct MyEnum {
    Archived,
    Resolver { field: u32 },
}
```