### PR TITLE
Fix Serialize macro for enums whos variants clash with associated types

### DIFF
--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -205,7 +205,7 @@ fn derive_serialize_impl(
             quote! {
                 impl #impl_generics Serialize<__S> for #name #ty_generics #serialize_where {
                     #[inline]
-                    fn serialize(&self, serializer: &mut __S) -> ::core::result::Result<Self::Resolver, __S::Error> {
+                    fn serialize(&self, serializer: &mut __S) -> ::core::result::Result<<Self as Archive>::Resolver, __S::Error> {
                         Ok(match self {
                             #(#serialize_arms,)*
                         })


### PR DESCRIPTION
Follow-up to #358, I forgot to check for the other derive macros 😅 
This fixes it for the `Serialize` derive macro and `Deserialize` is unaffected anyway.