### PR TITLE
Adds PartialOrd for ArchivedString <-> String

### DIFF
--- a/rkyv/src/string/mod.rs
+++ b/rkyv/src/string/mod.rs
@@ -215,6 +215,20 @@ impl PartialOrd<ArchivedString> for str {
     }
 }
 
+impl PartialOrd<ArchivedString> for String {
+    #[inline]
+    fn partial_cmp(&self, other: &ArchivedString) -> Option<cmp::Ordering> {
+        self.as_str().partial_cmp(other.as_str())
+    }
+}
+
+impl PartialOrd<String> for ArchivedString {
+    #[inline]
+    fn partial_cmp(&self, other: &String) -> Option<cmp::Ordering> {
+        self.as_str().partial_cmp(other.as_str())
+    }
+}
+
 /// The resolver for `String`.
 pub struct StringResolver {
     pos: usize,


### PR DESCRIPTION
A PartialOrd implementation to compare ArchivedString with String was still missing.
This implementation is important, because without it:

```rust
#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
#[archive_attr(derive(rkyv::CheckBytes))]
#[archive(compare(PartialEq, PartialOrd))] # <- especially this line
pub enum Value {
    Bool(bool),
    Int(i64),
    String(String)
}
```
will complain about the missing trait implementation.


This PR can be considered a follow up to #342 😊 