### PR TITLE
Disable android test targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       matrix:
         target:
-          - aarch64-linux-android
-          - arm-linux-androideabi
-          - armv7-linux-androideabi
-          - i686-linux-android
-          - x86_64-linux-android
+          # - aarch64-linux-android
+          # - arm-linux-androideabi
+          # - armv7-linux-androideabi
+          # - i686-linux-android
+          # - x86_64-linux-android
           - aarch64-unknown-linux-gnu
           - arm-unknown-linux-gnueabi
           - armv5te-unknown-linux-gnueabi


### PR DESCRIPTION
Cross's android images are causing CI to fail. Maybe related: https://github.com/cross-rs/cross/issues/975