### PR TITLE
rkyv_derive: only add CheckBytes derive when rkyv/validation is enabled

### DIFF
--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -50,7 +50,7 @@ alloc = ["hashbrown", "bitvec?/alloc", "tinyvec?/alloc"]
 std = ["alloc", "bytecheck?/std", "bytes?/std", "indexmap?/std", "ptr_meta/std", "uuid?/std"]
 copy = ["rkyv_derive/copy"]
 copy_unsafe = []
-bytecheck = ["dep:bytecheck", "alloc", "rend/bytecheck"]
+bytecheck = ["dep:bytecheck", "alloc", "rend/bytecheck", "rkyv_derive/bytecheck"]
 extra_traits = []
 
 # External crate support

--- a/rkyv_derive/Cargo.toml
+++ b/rkyv_derive/Cargo.toml
@@ -20,6 +20,7 @@ quote.workspace = true
 [features]
 default = []
 copy = []
+bytecheck  = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rkyv_derive/src/archive.rs
+++ b/rkyv_derive/src/archive.rs
@@ -55,7 +55,7 @@ fn derive_archive_impl(
     let with_ty = make_with_ty(&rkyv_path);
     let with_cast = make_with_cast(&rkyv_path);
 
-    let derive_check_bytes = if attributes.check_bytes.is_some() {
+    let derive_check_bytes = if attributes.check_bytes.is_some() && cfg!(feature = "bytecheck") {
         let path = quote!(#rkyv_path::bytecheck).to_string();
         let path_lit_str = LitStr::new(&path, rkyv_path.span());
         vec![


### PR DESCRIPTION
This removes the need for some crates to have both an rkyv and rkyv-validation feature (if they only use `archive(check_bytes)` for deriving CheckBytes).

Nonbreaking, as using `archive(check_bytes)` without enabling `rkyv/validation` would previously give a compile error.