### PR TITLE
Fix regression of version 0.7.40

### DIFF
--- a/rkyv/src/ser/serializers/core.rs
+++ b/rkyv/src/ser/serializers/core.rs
@@ -206,6 +206,7 @@ pub struct BufferScratch<T> {
 }
 
 unsafe impl<T> Send for BufferScratch<T> where T: Send {}
+unsafe impl<T> Sync for BufferScratch<T> where T: Sync {}
 
 impl<T> BufferScratch<T> {
     /// Creates a new buffer scratch allocator.


### PR DESCRIPTION
On version 0.7.39 `BufferScratch` was both `Send` + `Sync` but now it is just `Send` making async code harder.

cc #357