### PR TITLE
added `bytecheck?/uuid` to `uuid_std`

### DIFF
--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -52,6 +52,7 @@ validation = ["alloc", "bytecheck", "rend/validation"]
 bitvec_alloc = ["bitvec/alloc"]
 tinyvec_alloc = ["tinyvec/alloc"]
 uuid_std = ["uuid/std"]
+uuid_validation = ["uuid/std", "bytecheck/uuid"]
 
 [package.metadata.docs.rs]
 features = ["validation"]

--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -32,11 +32,11 @@ indexmap = { version = "1.7", optional = true, default-features = false }
 smallvec = { version = "1.7", optional = true, default-features = false }
 arrayvec = { version = "0.7", optional = true, default-features = false }
 tinyvec = { version = "1.5", optional = true, default-features = false }
-uuid = { version = "1.0", optional = true, default-features = false }
+uuid = { version = "1.3", optional = true, default-features = false }
 
 [features]
 default = ["size_32", "std"]
-alloc = ["hashbrown"]
+alloc = ["hashbrown", "bitvec?/alloc", "tinyvec?/alloc"]
 arbitrary_enum_discriminant = ["rkyv_derive/arbitrary_enum_discriminant"]
 archive_be = ["rend", "rkyv_derive/archive_be"]
 archive_le = ["rend", "rkyv_derive/archive_le"]
@@ -45,14 +45,10 @@ copy_unsafe = []
 size_16 = []
 size_32 = []
 size_64 = []
-std = ["alloc", "bytecheck/std", "ptr_meta/std", "rend/std"]
+std = ["alloc", "bytecheck?/std", "ptr_meta/std", "rend?/std", "uuid?/std"]
 strict = ["rkyv_derive/strict"]
+uuid = ["dep:uuid", "bytecheck?/uuid"]
 validation = ["alloc", "bytecheck", "rend/validation"]
-
-bitvec_alloc = ["bitvec/alloc"]
-tinyvec_alloc = ["tinyvec/alloc"]
-uuid_std = ["uuid/std"]
-uuid_validation = ["uuid/std", "bytecheck/uuid"]
 
 [package.metadata.docs.rs]
 features = ["validation"]


### PR DESCRIPTION
Since `rkyv/validation` does not expose the `CheckBytes` `Uuid`  impl by default, structs containing `Uuid`s are not able to be archived with the new `check_bytes` approach:
```
error[E0277]: the trait bound `uuid::Uuid: rkyv::CheckBytes<DefaultValidator<'_>>` is not satisfied
   --> src/lib.rs:853:29
    |
853 |             .filter_map(|v| rkyv::from_bytes::<MyUuidStruct>(&v).ok())
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `rkyv::CheckBytes<DefaultValidator<'_>>` is not implemented for `uuid::Uuid`
```