### PR TITLE
fix codes checking not exist features: tinyvec_alloc, bitvec_alloc

### DIFF
--- a/rkyv/src/impls/bitvec.rs
+++ b/rkyv/src/impls/bitvec.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "bitvec_alloc")]
+#[cfg(all(feature = "bitvec", feature = "alloc"))]
 use crate::vec::{ArchivedVec, VecResolver};
 use crate::{
     bitvec::ArchivedBitVec,
@@ -18,7 +18,7 @@ impl<T: BitStore + Archive, O: BitOrder> ArchivedBitVec<T, O> {
     }
 }
 
-#[cfg(feature = "bitvec_alloc")]
+#[cfg(all(feature = "bitvec", feature = "alloc"))]
 impl<T: BitStore + Archive, O: BitOrder> Archive for BitVec<T, O>
 where
     Archived<T>: BitStore,
@@ -34,7 +34,7 @@ where
     }
 }
 
-#[cfg(feature = "bitvec_alloc")]
+#[cfg(all(feature = "bitvec", feature = "alloc"))]
 impl<T, O, S> Serialize<S> for BitVec<T, O>
 where
     T: BitStore + Archive + Serialize<S>,
@@ -50,7 +50,7 @@ where
     }
 }
 
-#[cfg(feature = "bitvec_alloc")]
+#[cfg(all(feature = "bitvec", feature = "alloc"))]
 impl<T, O, D> Deserialize<BitVec<T, O>, D> for ArchivedBitVec<Archived<T>, O>
 where
     T: BitStore + Archive,
@@ -147,7 +147,7 @@ mod tests {
     use bitvec::prelude::*;
 
     #[test]
-    #[cfg(feature = "bitvec_alloc")]
+    #[cfg(all(feature = "bitvec", feature = "alloc"))]
     fn bitvec() {
         use crate::ser::serializers::CoreSerializer;
 

--- a/rkyv/src/impls/tinyvec.rs
+++ b/rkyv/src/impls/tinyvec.rs
@@ -3,7 +3,7 @@ use crate::{
     vec::{ArchivedVec, VecResolver},
     Archive, Archived, Deserialize, Fallible, Serialize,
 };
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 use tinyvec::TinyVec;
 use tinyvec::{Array, ArrayVec, SliceVec};
 
@@ -70,7 +70,7 @@ impl<'s, T: Serialize<S>, S: ScratchSpace + Serializer + ?Sized> Serialize<S> fo
 
 // TinyVec
 
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 impl<A: Array> Archive for TinyVec<A>
 where
     A::Item: Archive,
@@ -84,7 +84,7 @@ where
     }
 }
 
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 impl<A: Array, S: ScratchSpace + Serializer + ?Sized> Serialize<S> for TinyVec<A>
 where
     A::Item: Serialize<S>,
@@ -95,7 +95,7 @@ where
     }
 }
 
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 impl<A: Array, D: Fallible + ?Sized> Deserialize<TinyVec<A>, D> for ArchivedVec<Archived<A::Item>>
 where
     A::Item: Archive,
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(archived.as_slice(), &[10, 20, 40, 80]);
     }
 
-    #[cfg(feature = "tinyvec_alloc")]
+    #[cfg(all(feature = "tinyvec", feature = "alloc"))]
     #[test]
     fn tiny_vec() {
         use crate::ser::serializers::AllocSerializer;

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -96,8 +96,8 @@
 //! Support for each of these crates can be enabled with a feature of the same name. Additionally,
 //! the following external crate features are available:
 //!
-//! - `tinyvec_alloc`: Supports types behind the `alloc` feature in `tinyvec`.
-//! - `uuid_std`: Enables the `std` feature in `uuid`.
+//! - `tinyvec alloc`: Supports types behind the `alloc` feature in `tinyvec`.
+//! - `uuid std`: Enables the `std` feature in `uuid`.
 //!
 //! ## Examples
 //!


### PR DESCRIPTION
tinyvec_alloc and bitvec_alloc features were removed when they've included in alloc feature:
    "tinyvec?/alloc", "bitvec?/alloc"

but the codes are still checking with the old features.