### PR TITLE
Add tokio bytes support

### DIFF
--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -33,6 +33,7 @@ smallvec = { version = "1.7", optional = true, default-features = false }
 arrayvec = { version = "0.7", optional = true, default-features = false }
 tinyvec = { version = "1.5", optional = true, default-features = false }
 uuid = { version = "1.3", optional = true, default-features = false }
+bytes = { version = "1.4.0", optional = true, default-features = false }
 
 [features]
 default = ["size_32", "std"]
@@ -45,7 +46,7 @@ copy_unsafe = []
 size_16 = []
 size_32 = []
 size_64 = []
-std = ["alloc", "bytecheck?/std", "ptr_meta/std", "rend?/std", "uuid?/std"]
+std = ["alloc", "bytecheck?/std", "ptr_meta/std", "rend?/std", "uuid?/std", "bytes?/std"]
 strict = ["rkyv_derive/strict"]
 uuid = ["dep:uuid", "bytecheck?/uuid"]
 validation = ["alloc", "bytecheck", "rend/validation"]

--- a/rkyv/src/impls/bytes.rs
+++ b/rkyv/src/impls/bytes.rs
@@ -1,0 +1,64 @@
+use crate::{
+    ser::{ScratchSpace, Serializer},
+    vec::{ArchivedVec, VecResolver},
+    Archive, Archived, Deserialize, Fallible, Serialize,
+};
+use bytes::{Bytes, BytesMut};
+
+impl Archive for Bytes {
+    type Archived = ArchivedVec<u8>;
+    type Resolver = VecResolver;
+
+    #[inline]
+    unsafe fn resolve(&self, pos: usize, resolver: Self::Resolver, out: *mut Self::Archived) {
+        ArchivedVec::resolve_from_slice(self, pos, resolver, out);
+    }
+}
+
+impl<S: ScratchSpace + Serializer + ?Sized> Serialize<S> for Bytes {
+    #[inline]
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        ArchivedVec::serialize_from_slice(self, serializer)
+    }
+}
+
+impl<D: Fallible + ?Sized> Deserialize<Bytes, D> for ArchivedVec<Archived<u8>> {
+    #[inline]
+    fn deserialize(&self, _deserializer: &mut D) -> Result<Bytes, D::Error> {
+        let mut result = BytesMut::new();
+        result.extend_from_slice(self.as_slice());
+        Ok(result.freeze())
+    }
+}
+
+impl<T: Archive> PartialEq<Bytes> for ArchivedVec<T>
+where
+    bytes::Bytes: PartialEq<[T]>,
+{
+    fn eq(&self, other: &Bytes) -> bool {
+        other == self.as_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{archived_root, ser::Serializer, Deserialize, Infallible};
+    use bytes::Bytes;
+
+    #[test]
+    fn bytes() {
+        use crate::ser::serializers::CoreSerializer;
+
+        let value = Bytes::from(vec![10, 20, 40, 80]);
+
+        let mut serializer = CoreSerializer::<256, 256>::default();
+        serializer.serialize_value(&value).unwrap();
+        let end = serializer.pos();
+        let result = serializer.into_serializer().into_inner();
+        let archived = unsafe { archived_root::<Bytes>(&result[0..end]) };
+        assert_eq!(archived, &value);
+
+        let deserialized: Bytes = archived.deserialize(&mut Infallible).unwrap();
+        assert_eq!(value, deserialized);
+    }
+}

--- a/rkyv/src/impls/mod.rs
+++ b/rkyv/src/impls/mod.rs
@@ -17,6 +17,8 @@ mod std;
 mod arrayvec;
 #[cfg(feature = "bitvec")]
 mod bitvec;
+#[cfg(feature = "bytes")]
+mod bytes;
 #[cfg(feature = "hashbrown")]
 mod hashbrown;
 #[cfg(feature = "indexmap")]


### PR DESCRIPTION
A fairly straight forward addition for using tokio's bytes crate with rkyv. I've tested it with my app as well as a module test I've added, and it seems to be working correctly.

Please let me know if you have any suggestions/changes.

Closes https://github.com/rkyv/rkyv/issues/314