### PR TITLE
Add smol_str support

### DIFF
--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -30,6 +30,7 @@ seahash = "4.0"
 bitvec = { version = "1.0", optional = true, default-features = false }
 indexmap = { version = "1.7", optional = true, default-features = false }
 smallvec = { version = "1.7", optional = true, default-features = false }
+smol_str = { version = "0.2", optional = true, default-features = false }
 arrayvec = { version = "0.7", optional = true, default-features = false }
 tinyvec = { version = "1.5", optional = true, default-features = false }
 uuid = { version = "1.3", optional = true, default-features = false }

--- a/rkyv/src/collections/hash_map/mod.rs
+++ b/rkyv/src/collections/hash_map/mod.rs
@@ -147,7 +147,11 @@ impl<K, V> ArchivedHashMap<K, V> {
     /// ```
     ///
     #[inline]
-    pub fn get_with<Q: Hash + ?Sized, F: Fn(&K, &Q) -> bool>(&self, key: &Q, comparison_predicate: F) -> Option<&V> {
+    pub fn get_with<Q: Hash + ?Sized, F: Fn(&K, &Q) -> bool>(
+        &self,
+        key: &Q,
+        comparison_predicate: F,
+    ) -> Option<&V> {
         // Code adapted from self.find
         self.index.index(key).and_then(|i| {
             // Safety: We know the index for self.entry() here is right

--- a/rkyv/src/impls/alloc/string.rs
+++ b/rkyv/src/impls/alloc/string.rs
@@ -2,9 +2,9 @@ use crate::{
     string::{ArchivedString, StringResolver},
     Archive, Deserialize, DeserializeUnsized, Fallible, Serialize, SerializeUnsized,
 };
-use ::core::cmp::Ordering;
 #[cfg(not(feature = "std"))]
 use ::alloc::string::{String, ToString};
+use ::core::cmp::Ordering;
 
 impl Archive for String {
     type Archived = ArchivedString;

--- a/rkyv/src/impls/mod.rs
+++ b/rkyv/src/impls/mod.rs
@@ -25,6 +25,8 @@ mod hashbrown;
 mod indexmap;
 #[cfg(feature = "smallvec")]
 mod smallvec;
+#[cfg(feature = "smol_str")]
+mod smolstr;
 #[cfg(feature = "tinyvec")]
 mod tinyvec;
 #[cfg(feature = "uuid")]

--- a/rkyv/src/impls/smolstr.rs
+++ b/rkyv/src/impls/smolstr.rs
@@ -25,12 +25,7 @@ impl<S: ScratchSpace + Serializer + ?Sized> Serialize<S> for SmolStr {
 impl<D: Fallible + ?Sized> Deserialize<SmolStr, D> for ArchivedString {
     #[inline]
     fn deserialize(&self, _deserializer: &mut D) -> Result<SmolStr, D::Error> {
-        Ok(if self.as_str().len() <= 23 {
-            // SmolStr will be on the stack if length less than 23
-            SmolStr::new_inline(self.as_str())
-        } else {
-            SmolStr::new(self.as_str())
-        })
+        Ok(SmolStr::new(self.as_str()))
     }
 }
 

--- a/rkyv/src/impls/smolstr.rs
+++ b/rkyv/src/impls/smolstr.rs
@@ -1,0 +1,64 @@
+use crate::{
+    ser::{ScratchSpace, Serializer},
+    string::{ArchivedString, StringResolver},
+    Archive, Deserialize, Fallible, Serialize,
+};
+use smol_str::SmolStr;
+
+impl Archive for SmolStr {
+    type Archived = ArchivedString;
+    type Resolver = StringResolver;
+
+    #[inline]
+    unsafe fn resolve(&self, pos: usize, resolver: Self::Resolver, out: *mut Self::Archived) {
+        ArchivedString::resolve_from_str(self, pos, resolver, out);
+    }
+}
+
+impl<S: ScratchSpace + Serializer + ?Sized> Serialize<S> for SmolStr {
+    #[inline]
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        ArchivedString::serialize_from_str(self, serializer)
+    }
+}
+
+impl<D: Fallible + ?Sized> Deserialize<SmolStr, D> for ArchivedString {
+    #[inline]
+    fn deserialize(&self, _deserializer: &mut D) -> Result<SmolStr, D::Error> {
+        Ok(if self.as_str().len() <= 23 {
+            // SmolStr will be on the stack if length less than 23
+            SmolStr::new_inline(self.as_str())
+        } else {
+            SmolStr::new(self.as_str())
+        })
+    }
+}
+
+impl PartialEq<SmolStr> for ArchivedString {
+    fn eq(&self, other: &SmolStr) -> bool {
+        other.as_str() == self.as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{archived_root, ser::Serializer, Deserialize, Infallible};
+    use smol_str::SmolStr;
+
+    #[test]
+    fn smolstr() {
+        use crate::ser::serializers::CoreSerializer;
+
+        let value = SmolStr::new("smol_str");
+
+        let mut serializer = CoreSerializer::<256, 256>::default();
+        serializer.serialize_value(&value).unwrap();
+        let end = serializer.pos();
+        let result = serializer.into_serializer().into_inner();
+        let archived = unsafe { archived_root::<SmolStr>(&result[0..end]) };
+        assert_eq!(archived, &value);
+
+        let deserialized: SmolStr = archived.deserialize(&mut Infallible).unwrap();
+        assert_eq!(value, deserialized);
+    }
+}

--- a/rkyv_test/src/test_std.rs
+++ b/rkyv_test/src/test_std.rs
@@ -71,14 +71,22 @@ mod tests {
     fn archive_hash_map_tuple_retrieved_by_get_with() {
         let mut hash_map = HashMap::new();
         hash_map.insert(("my".to_string(), "key".to_string()), "value".to_string());
-        hash_map.insert(("wrong".to_string(), "key".to_string()), "wrong value".to_string());
+        hash_map.insert(
+            ("wrong".to_string(), "key".to_string()),
+            "wrong value".to_string(),
+        );
 
         let mut serializer = DefaultSerializer::default();
         serializer.serialize_value(&hash_map).unwrap();
         let buf = serializer.into_serializer().into_inner();
-        let archived_value = unsafe { archived_root::<HashMap<(String, String), String>>(buf.as_ref()) };
+        let archived_value =
+            unsafe { archived_root::<HashMap<(String, String), String>>(buf.as_ref()) };
 
-        let get_with = archived_value.get_with(&("my", "key"), |key, input_key| &(key.0.as_str(), key.1.as_str()) == input_key).unwrap();
+        let get_with = archived_value
+            .get_with(&("my", "key"), |key, input_key| {
+                &(key.0.as_str(), key.1.as_str()) == input_key
+            })
+            .unwrap();
 
         assert_eq!(get_with.as_str(), "value");
     }

--- a/rkyv_typename/src/lib.rs
+++ b/rkyv_typename/src/lib.rs
@@ -93,7 +93,10 @@ pub trait TypeName {
     fn build_type_name<F: FnMut(&str)>(f: F);
 }
 
-impl<T: TypeName> TypeName for &T where T: ?Sized {
+impl<T: TypeName> TypeName for &T
+where
+    T: ?Sized,
+{
     fn build_type_name<F: FnMut(&str)>(mut f: F) {
         f("&");
         T::build_type_name(f);

--- a/rkyv_typename/tests/test_derive.rs
+++ b/rkyv_typename/tests/test_derive.rs
@@ -247,7 +247,8 @@ fn composite_cases() {
                 [u16], \
                 33, \
                 false\
-        >")
+        >"
+        )
         .as_str(),
     );
 }

--- a/rkyv_typename_derive/src/lib.rs
+++ b/rkyv_typename_derive/src/lib.rs
@@ -11,7 +11,7 @@ extern crate proc_macro;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    parse_macro_input, spanned::Spanned, AttrStyle, DeriveInput, Error, Lit, Meta, GenericParam
+    parse_macro_input, spanned::Spanned, AttrStyle, DeriveInput, Error, GenericParam, Lit, Meta,
 };
 
 #[derive(Default)]
@@ -92,7 +92,7 @@ fn derive_type_name_impl(input: &DeriveInput) -> TokenStream {
             }
             GenericParam::Const(c) => {
                 let value = &c.ident;
-                Some(quote!{
+                Some(quote! {
                     // This works for all const generic types that are supported by rust 1.68 or
                     // below. It happens to be, for these types, that the Debug trait is
                     // implemented in such a way that it generates the correct output for the
@@ -122,11 +122,8 @@ fn derive_type_name_impl(input: &DeriveInput) -> TokenStream {
         }
     };
 
-    let (impl_generics, ty_generics, where_clause) =
-        input.generics.split_for_impl();
-    let standard_derive_where_predicates = where_clause.map(
-        |w|&w.predicates
-    );
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let standard_derive_where_predicates = where_clause.map(|w| &w.predicates);
     quote! {
         const _: () = {
             use rkyv_typename::TypeName;


### PR DESCRIPTION
A straightforward addition for using rust-analyzer's [`smol_str`](https://crates.io/crates/smol_str) crate with `rkyv`.