### PR TITLE
dep(rkyv): don't bring in rend with validation

### DIFF
--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -48,7 +48,7 @@ std = ["alloc", "bytecheck?/std", "ptr_meta/std", "uuid?/std", "bytes?/std"]
 strict = ["rkyv_derive/strict"]
 copy = ["rkyv_derive/copy"]
 copy_unsafe = []
-validation = ["alloc", "bytecheck", "rend/validation"]
+validation = ["alloc", "bytecheck", "rend?/validation"]
 
 # Crate support
 uuid = ["dep:uuid", "bytecheck?/uuid"]


### PR DESCRIPTION
Enabling the `validation` feature currently always brings in the optional `rend` dependency.

All usages of `rend` seem to be either behind the `archive_le` or `archive_be` features so `validation` should not depend on it.