### PR TITLE
dep(derive): bumped syn to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ quote = "1.0"
 rend = { version = "0.5", git = "https://github.com/rkyv/rend", branch = "master", default-features = false }
 rkyv_derive = { version = "=0.8.0", path = "rkyv_derive" }
 seahash = "4.0"
-syn = "1.0"
+syn = "2.0"
 wasm-bindgen-test = "0.3"

--- a/rkyv_derive/Cargo.toml
+++ b/rkyv_derive/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2.workspace = true
-syn.workspace = true
+syn = { workspace = true, features = ["full"] }
 quote.workspace = true
 
 [features]

--- a/rkyv_derive/src/deserialize.rs
+++ b/rkyv_derive/src/deserialize.rs
@@ -53,7 +53,7 @@ fn derive_deserialize_impl(
             Fields::Named(ref fields) => {
                 let mut deserialize_where = where_clause.clone();
                 for field in fields.named.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     deserialize_where
@@ -94,7 +94,7 @@ fn derive_deserialize_impl(
             Fields::Unnamed(ref fields) => {
                 let mut deserialize_where = where_clause.clone();
                 for field in fields.unnamed.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     deserialize_where
@@ -150,7 +150,7 @@ fn derive_deserialize_impl(
                         for field in fields.named.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             deserialize_where
@@ -165,7 +165,7 @@ fn derive_deserialize_impl(
                         for field in fields.unnamed.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             deserialize_where

--- a/rkyv_derive/src/serde/receiver.rs
+++ b/rkyv_derive/src/serde/receiver.rs
@@ -155,7 +155,6 @@ impl ReplaceReceiver<'_> {
             }
 
             Type::Infer(_) | Type::Never(_) | Type::Verbatim(_) => {}
-
             _ => {}
         }
     }
@@ -187,12 +186,14 @@ impl ReplaceReceiver<'_> {
                 for arg in &mut arguments.args {
                     match arg {
                         GenericArgument::Type(arg) => self.visit_type_mut(arg),
-                        GenericArgument::Binding(arg) => {
+                        GenericArgument::AssocType(arg) => {
                             self.visit_type_mut(&mut arg.ty)
                         }
                         GenericArgument::Lifetime(_)
-                        | GenericArgument::Constraint(_)
-                        | GenericArgument::Const(_) => {}
+                        | GenericArgument::Const(_)
+                        | GenericArgument::AssocConst(_)
+                        | GenericArgument::Constraint(_) => {}
+                        _ => {}
                     }
                 }
             }
@@ -217,7 +218,8 @@ impl ReplaceReceiver<'_> {
             TypeParamBound::Trait(bound) => {
                 self.visit_path_mut(&mut bound.path)
             }
-            TypeParamBound::Lifetime(_) => {}
+            TypeParamBound::Lifetime(_) | TypeParamBound::Verbatim(_) => {}
+            _ => {}
         }
     }
 
@@ -241,7 +243,8 @@ impl ReplaceReceiver<'_> {
                             self.visit_type_param_bound_mut(bound);
                         }
                     }
-                    WherePredicate::Lifetime(_) | WherePredicate::Eq(_) => {}
+                    WherePredicate::Lifetime(_) => {}
+                    _ => {}
                 }
             }
         }

--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -59,7 +59,7 @@ fn derive_serialize_impl(
             Fields::Named(ref fields) => {
                 let mut serialize_where = where_clause.clone();
                 for field in fields.named.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     serialize_where
@@ -87,7 +87,7 @@ fn derive_serialize_impl(
             Fields::Unnamed(ref fields) => {
                 let mut serialize_where = where_clause.clone();
                 for field in fields.unnamed.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     serialize_where
@@ -131,7 +131,7 @@ fn derive_serialize_impl(
                         for field in fields.named.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             serialize_where
@@ -143,7 +143,7 @@ fn derive_serialize_impl(
                         for field in fields.unnamed.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             serialize_where

--- a/rkyv_derive/src/util.rs
+++ b/rkyv_derive/src/util.rs
@@ -1,18 +1,20 @@
 use proc_macro2::Ident;
 use syn::{
-    punctuated::Punctuated, Error, LitStr, Token, WhereClause, WherePredicate,
+    parse::{Parse, ParseStream},
+    token::Token as TokenTrait,
+    Error, LitStr, Token, WhereClause,
 };
 
 pub fn add_bounds(
     bounds: &LitStr,
     where_clause: &mut WhereClause,
 ) -> Result<(), Error> {
-    let clauses = bounds.parse_with(
-        Punctuated::<WherePredicate, Token![,]>::parse_terminated,
-    )?;
+    let clauses = bounds.parse_with(Vec::parse_terminated::<Token![,]>)?;
+
     for clause in clauses {
         where_clause.predicates.push(clause);
     }
+
     Ok(())
 }
 
@@ -22,4 +24,104 @@ pub fn strip_raw(ident: &Ident) -> String {
         .strip_prefix("r#")
         .map(ToString::to_string)
         .unwrap_or(as_string)
+}
+
+/// Revamping utility from [`Punctuated`] for the purpose of storing items
+/// more efficiently.
+///
+/// [`Punctuated`]: syn::punctuated::Punctuated
+pub trait PunctuatedExt<T> {
+    /// Parses one or more occurrences of `T` separated by punctuation of type
+    /// `P`, not accepting trailing punctuation.
+    ///
+    /// Parsing continues as long as punctuation `P` is present at the head of
+    /// the stream. This method returns upon parsing a `T` and observing that it
+    /// is not followed by a `P`, even if there are remaining tokens in the
+    /// stream.
+    fn parse_separated_nonempty<P: Parse + TokenTrait>(
+        input: ParseStream,
+    ) -> Result<Vec<T>, Error>
+    where
+        T: Parse,
+    {
+        Self::parse_separated_nonempty_with::<P>(input, T::parse)
+    }
+
+    /// Parses one or more occurrences of `T` using the given parse function,
+    /// separated by punctuation of type `P`, not accepting trailing
+    /// punctuation.
+    ///
+    /// Like [`parse_separated_nonempty`], may complete early without parsing
+    /// the entire content of this stream.
+    fn parse_separated_nonempty_with<P: Parse + TokenTrait>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Vec<T>, Error>;
+
+    /// Parses zero or more occurrences of `T` separated by punctuation of type
+    /// `P`, with optional trailing punctuation.
+    ///
+    /// Parsing continues until the end of this parse stream. The entire content
+    /// of this parse stream must consist of `T` and `P`.
+    fn parse_terminated<P: Parse>(input: ParseStream) -> Result<Vec<T>, Error>
+    where
+        T: Parse,
+    {
+        Self::parse_terminated_with::<P>(input, T::parse)
+    }
+
+    /// Parses zero or more occurrences of `T` using the given parse function,
+    /// separated by punctuation of type `P`, with optional trailing
+    /// punctuation.
+    ///
+    /// Like [`parse_terminated`], the entire content of this stream is expected
+    /// to be parsed.
+    fn parse_terminated_with<P: Parse>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Vec<T>, Error>;
+}
+
+impl<T> PunctuatedExt<T> for Vec<T> {
+    fn parse_separated_nonempty_with<P: Parse + TokenTrait>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Self, Error> {
+        let mut vec = Vec::new();
+
+        loop {
+            vec.push(parser(input)?);
+
+            if !P::peek(input.cursor()) {
+                break;
+            }
+
+            input.parse::<P>()?;
+        }
+
+        Ok(vec)
+    }
+
+    fn parse_terminated_with<P: Parse>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Self, Error> {
+        let mut vec = Vec::new();
+
+        loop {
+            if input.is_empty() {
+                break;
+            }
+
+            vec.push(parser(input)?);
+
+            if input.is_empty() {
+                break;
+            }
+
+            input.parse::<P>()?;
+        }
+
+        Ok(vec)
+    }
 }

--- a/rkyv_derive/src/with.rs
+++ b/rkyv_derive/src/with.rs
@@ -1,7 +1,6 @@
-use syn::{
-    parse_quote, punctuated::Punctuated, token::Comma, Error, Expr, Field,
-    Path, Type,
-};
+use syn::{parse_quote, Error, Expr, Field, Path, Token, Type};
+
+use crate::util::PunctuatedExt;
 
 #[inline]
 pub fn with<B, F: FnMut(B, &Type) -> B>(
@@ -13,9 +12,9 @@ pub fn with<B, F: FnMut(B, &Type) -> B>(
         .attrs
         .iter()
         .filter_map(|attr| {
-            if attr.path.is_ident("with") {
+            if attr.path().is_ident("with") {
                 Some(attr.parse_args_with(
-                    Punctuated::<Type, Comma>::parse_separated_nonempty,
+                    Vec::parse_separated_nonempty::<Token![,]>,
                 ))
             } else {
                 None


### PR DESCRIPTION
Updated `syn` from `1.0` to `2.0`.

Essentially only the attribute parsing was affected. I checked (hopefully) all cases of invalid user input to make sure the errors stay the same or are still appropriate.
The `serde` module was updated by copying from the serde repository again.

There was one `TODO` in the code regarding `archive(repr(...))` which I kept in.