### PR TITLE
Preallocate HashMap/HashSet data on deserialize

### DIFF
--- a/rkyv/src/with/impls/std.rs
+++ b/rkyv/src/with/impls/std.rs
@@ -280,7 +280,7 @@ where
         field: &ArchivedVec<Entry<K::Archived, V::Archived>>,
         deserializer: &mut D,
     ) -> Result<HashMap<K, V>, D::Error> {
-        let mut result = HashMap::new();
+        let mut result = HashMap::with_capacity(field.len());
         for entry in field.iter() {
             result.insert(
                 entry.key.deserialize(deserializer)?,
@@ -331,7 +331,7 @@ where
         field: &ArchivedVec<T::Archived>,
         deserializer: &mut D,
     ) -> Result<HashSet<T>, D::Error> {
-        let mut result = HashSet::new();
+        let mut result = HashSet::with_capacity(field.len());
         for key in field.iter() {
             result.insert(key.deserialize(deserializer)?);
         }


### PR DESCRIPTION
With the `With<AsVec>` decorator, data size is knonwn in beforehand, and even if theoretically repeated values can present hand-crafted in the data, we may be optimistic about result size.

It makes certain data to deserialize 5% faster (other kinds of data may have even better improvement).