### PR TITLE
`with_capacity` constructor for certain types

### DIFF
--- a/rkyv/src/de/deserializers/alloc.rs
+++ b/rkyv/src/de/deserializers/alloc.rs
@@ -57,6 +57,14 @@ impl SharedDeserializeMap {
             shared_pointers: hash_map::HashMap::new(),
         }
     }
+
+    /// Wraps the given deserializer and adds shared memory support, with initial capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            shared_pointers: hash_map::HashMap::with_capacity(capacity),
+        }
+    }
 }
 
 impl fmt::Debug for SharedDeserializeMap {

--- a/rkyv/src/ser/serializers/alloc.rs
+++ b/rkyv/src/ser/serializers/alloc.rs
@@ -400,6 +400,14 @@ impl SharedSerializeMap {
             shared_resolvers: hash_map::HashMap::new(),
         }
     }
+
+    /// Creates a new shared registry map with initial capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            shared_resolvers: hash_map::HashMap::with_capacity(capacity),
+        }
+    }
 }
 
 impl Default for SharedSerializeMap {

--- a/rkyv/src/validation/validators/mod.rs
+++ b/rkyv/src/validation/validators/mod.rs
@@ -69,6 +69,15 @@ impl<'a> DefaultValidator<'a> {
             shared: SharedValidator::new(),
         }
     }
+
+    /// Create a new validator from a byte range with specific capacity.
+    #[inline]
+    pub fn with_capacity(bytes: &'a [u8], capacity: usize) -> Self {
+        Self {
+            archive: ArchiveValidator::new(bytes),
+            shared: SharedValidator::with_capacity(capacity),
+        }
+    }
 }
 
 impl<'a> Fallible for DefaultValidator<'a> {

--- a/rkyv/src/validation/validators/shared.rs
+++ b/rkyv/src/validation/validators/shared.rs
@@ -69,6 +69,14 @@ impl SharedValidator {
             shared: HashMap::new(),
         }
     }
+
+    /// Shared memory validator with specific capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            shared: HashMap::with_capacity(capacity),
+        }
+    }
 }
 
 impl Default for SharedValidator {


### PR DESCRIPTION
Preallocating internal data strucutres make various operations 5-15% faster.