### PR TITLE
Add ThinVec and triomphe::Arc support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ quote = "1.0"
 rend = { version = "0.5", git = "https://github.com/rkyv/rend", branch = "master", default-features = false }
 rkyv_derive = { version = "=0.8.0", path = "rkyv_derive" }
 seahash = "4.0"
-syn = "1.0"
+syn = "2.0"
 wasm-bindgen-test = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/rkyv/rkyv"
 
 [workspace.dependencies]
 bytecheck = { version = "0.7", default-features = false }
-hashbrown = "0.12"
+hashbrown = "0.14"
 proc-macro2 = "1.0"
 ptr_meta = { version = "0.2", default-features = false }
 quote = "1.0"

--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -35,6 +35,8 @@ arrayvec = { version = "0.7", optional = true, default-features = false }
 tinyvec = { version = "1.5", optional = true, default-features = false }
 uuid = { version = "1.3", optional = true, default-features = false }
 bytes = { version = "1.4.0", optional = true, default-features = false }
+thin-vec = { version = "0.2.12", optional = true, default-features = false }
+triomphe = { version = "0.1", optional = true, default-features = false }
 
 [features]
 default = ["little_endian", "pointer_width_32", "std", "strict", "validation"]

--- a/rkyv/src/de/deserializers/alloc.rs
+++ b/rkyv/src/de/deserializers/alloc.rs
@@ -57,6 +57,14 @@ impl SharedDeserializeMap {
             shared_pointers: hash_map::HashMap::new(),
         }
     }
+
+    /// Wraps the given deserializer and adds shared memory support, with initial capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            shared_pointers: hash_map::HashMap::with_capacity(capacity),
+        }
+    }
 }
 
 impl fmt::Debug for SharedDeserializeMap {

--- a/rkyv/src/impls/mod.rs
+++ b/rkyv/src/impls/mod.rs
@@ -27,7 +27,11 @@ mod indexmap;
 mod smallvec;
 #[cfg(feature = "smol_str")]
 mod smolstr;
+#[cfg(feature = "thin-vec")]
+mod thin_vec;
 #[cfg(feature = "tinyvec")]
 mod tinyvec;
+#[cfg(feature = "triomphe")]
+mod triomphe;
 #[cfg(feature = "uuid")]
 mod uuid;

--- a/rkyv/src/impls/thin_vec.rs
+++ b/rkyv/src/impls/thin_vec.rs
@@ -1,0 +1,57 @@
+use crate::{
+    ser::{ScratchSpace, Serializer},
+    vec::{ArchivedVec, VecResolver},
+    Archive, Archived, Deserialize, Fallible, Serialize,
+};
+
+use thin_vec::ThinVec;
+
+impl<T> Archive for ThinVec<T>
+where
+    T: Archive,
+{
+    type Archived = ArchivedVec<Archived<T>>;
+    type Resolver = VecResolver;
+
+    #[inline]
+    unsafe fn resolve(
+        &self,
+        pos: usize,
+        resolver: Self::Resolver,
+        out: *mut Self::Archived,
+    ) {
+        ArchivedVec::resolve_from_slice(self.as_slice(), pos, resolver, out);
+    }
+}
+
+impl<T, S: ScratchSpace + Serializer + ?Sized> Serialize<S> for ThinVec<T>
+where
+    T: Serialize<S>,
+{
+    #[inline]
+    fn serialize(
+        &self,
+        serializer: &mut S,
+    ) -> Result<Self::Resolver, S::Error> {
+        ArchivedVec::serialize_from_slice(self.as_slice(), serializer)
+    }
+}
+
+impl<T, D: Fallible + ?Sized> Deserialize<ThinVec<T>, D>
+    for ArchivedVec<Archived<T>>
+where
+    T: Archive,
+    Archived<T>: Deserialize<T, D>,
+{
+    #[inline]
+    fn deserialize(
+        &self,
+        deserializer: &mut D,
+    ) -> Result<ThinVec<T>, D::Error> {
+        let mut result = ThinVec::with_capacity(self.len());
+        for item in self.as_slice() {
+            result.push(item.deserialize(deserializer)?);
+        }
+        Ok(result)
+    }
+}

--- a/rkyv/src/impls/tinyvec.rs
+++ b/rkyv/src/impls/tinyvec.rs
@@ -3,7 +3,7 @@ use crate::{
     vec::{ArchivedVec, VecResolver},
     Archive, Archived, Deserialize, Fallible, Serialize,
 };
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 use tinyvec::TinyVec;
 use tinyvec::{Array, ArrayVec, SliceVec};
 
@@ -93,7 +93,7 @@ impl<'s, T: Serialize<S>, S: ScratchSpace + Serializer + ?Sized> Serialize<S>
 
 // TinyVec
 
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 impl<A: Array> Archive for TinyVec<A>
 where
     A::Item: Archive,
@@ -112,7 +112,7 @@ where
     }
 }
 
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 impl<A: Array, S: ScratchSpace + Serializer + ?Sized> Serialize<S>
     for TinyVec<A>
 where
@@ -127,7 +127,7 @@ where
     }
 }
 
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 impl<A: Array, D: Fallible + ?Sized> Deserialize<TinyVec<A>, D>
     for ArchivedVec<Archived<A::Item>>
 where
@@ -191,7 +191,7 @@ mod tests {
         assert_eq!(archived.as_slice(), &[10, 20, 40, 80]);
     }
 
-    #[cfg(feature = "tinyvec_alloc")]
+    #[cfg(all(feature = "tinyvec", feature = "alloc"))]
     #[test]
     fn tiny_vec() {
         use crate::ser::serializers::AllocSerializer;

--- a/rkyv/src/impls/triomphe.rs
+++ b/rkyv/src/impls/triomphe.rs
@@ -1,0 +1,75 @@
+use crate::{
+    de::{SharedDeserializeRegistry, SharedPointer},
+    rc::{ArchivedRc, RcResolver},
+    ser::{Serializer, SharedSerializeRegistry},
+    Archive, ArchiveUnsized, Deserialize, DeserializeUnsized, Serialize,
+    SerializeUnsized,
+};
+
+#[cfg(not(feature = "std"))]
+use alloc::{alloc, boxed::Box};
+#[cfg(feature = "std")]
+use std::alloc;
+
+use core::mem::forget;
+
+use triomphe::Arc;
+
+pub struct TriompheArcFlavor;
+
+impl<T: ?Sized> SharedPointer for Arc<T> {
+    #[inline]
+    fn data_address(&self) -> *const () {
+        Arc::as_ptr(self) as *const ()
+    }
+}
+
+impl<T: ArchiveUnsized + ?Sized> Archive for Arc<T> {
+    type Archived = ArchivedRc<T::Archived, TriompheArcFlavor>;
+    type Resolver = RcResolver<T::MetadataResolver>;
+
+    #[inline]
+    unsafe fn resolve(
+        &self,
+        pos: usize,
+        resolver: Self::Resolver,
+        out: *mut Self::Archived,
+    ) {
+        ArchivedRc::resolve_from_ref(self.as_ref(), pos, resolver, out);
+    }
+}
+
+impl<T, S> Serialize<S> for Arc<T>
+where
+    T: SerializeUnsized<S> + ?Sized + 'static,
+    S: Serializer + SharedSerializeRegistry + ?Sized,
+{
+    #[inline]
+    fn serialize(
+        &self,
+        serializer: &mut S,
+    ) -> Result<Self::Resolver, S::Error> {
+        ArchivedRc::<T::Archived, TriompheArcFlavor>::serialize_from_ref(
+            self.as_ref(),
+            serializer,
+        )
+    }
+}
+
+impl<T: ArchiveUnsized + 'static, D: SharedDeserializeRegistry + ?Sized>
+    Deserialize<Arc<T>, D> for ArchivedRc<T::Archived, TriompheArcFlavor>
+where
+    T::Archived: DeserializeUnsized<T, D>,
+{
+    #[inline]
+    fn deserialize(&self, deserializer: &mut D) -> Result<Arc<T>, D::Error> {
+        let raw_shared_ptr = deserializer.deserialize_shared(
+            self.get(),
+            |ptr| Arc::<T>::from(unsafe { Box::from_raw(ptr) }),
+            |layout| unsafe { alloc::alloc(layout) },
+        )?;
+        let shared_ptr = unsafe { Arc::<T>::from_raw(raw_shared_ptr) };
+        forget(shared_ptr.clone());
+        Ok(shared_ptr)
+    }
+}

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -94,8 +94,8 @@
 //! Support for each of these crates can be enabled with a feature of the same name. Additionally,
 //! the following external crate features are available:
 //!
-//! - `tinyvec_alloc`: Supports types behind the `alloc` feature in `tinyvec`.
-//! - `uuid_std`: Enables the `std` feature in `uuid`.
+//! - `alloc` with `tinyvec/alloc`: Supports types behind the `alloc` feature in `tinyvec`.
+//! - `std` with `uuid/std`: Enables the `std` feature in `uuid`.
 //!
 //! ## Examples
 //!

--- a/rkyv/src/ser/serializers/alloc.rs
+++ b/rkyv/src/ser/serializers/alloc.rs
@@ -400,6 +400,14 @@ impl SharedSerializeMap {
             shared_resolvers: hash_map::HashMap::new(),
         }
     }
+
+    /// Creates a new shared registry map with initial capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            shared_resolvers: hash_map::HashMap::with_capacity(capacity),
+        }
+    }
 }
 
 impl Default for SharedSerializeMap {

--- a/rkyv/src/util/mod.rs
+++ b/rkyv/src/util/mod.rs
@@ -43,7 +43,7 @@ fn check_alignment<T>(ptr: *const u8) {
         concat!(
             "unaligned buffer, expected alignment {} but found alignment {}\n",
             "help: rkyv requires byte buffers to be aligned to access the data inside.\n",
-            "      Using an ALignedVec or manually aligning your data with #[align(...)]\n",
+            "      Using an AlignedVec or manually aligning your data with #[align(...)]\n",
             "      may resolve this issue.",
         ),
         expect_align,

--- a/rkyv/src/validation/validators/mod.rs
+++ b/rkyv/src/validation/validators/mod.rs
@@ -69,6 +69,15 @@ impl<'a> DefaultValidator<'a> {
             shared: SharedValidator::new(),
         }
     }
+
+    /// Create a new validator from a byte range with specific capacity.
+    #[inline]
+    pub fn with_capacity(bytes: &'a [u8], capacity: usize) -> Self {
+        Self {
+            archive: ArchiveValidator::new(bytes),
+            shared: SharedValidator::with_capacity(capacity),
+        }
+    }
 }
 
 impl<'a> Fallible for DefaultValidator<'a> {

--- a/rkyv/src/validation/validators/shared.rs
+++ b/rkyv/src/validation/validators/shared.rs
@@ -69,6 +69,14 @@ impl SharedValidator {
             shared: HashMap::new(),
         }
     }
+
+    /// Shared memory validator with specific capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            shared: HashMap::with_capacity(capacity),
+        }
+    }
 }
 
 impl Default for SharedValidator {

--- a/rkyv/src/with/impls/std.rs
+++ b/rkyv/src/with/impls/std.rs
@@ -280,7 +280,7 @@ where
         field: &ArchivedVec<Entry<K::Archived, V::Archived>>,
         deserializer: &mut D,
     ) -> Result<HashMap<K, V>, D::Error> {
-        let mut result = HashMap::new();
+        let mut result = HashMap::with_capacity(field.len());
         for entry in field.iter() {
             result.insert(
                 entry.key.deserialize(deserializer)?,
@@ -331,7 +331,7 @@ where
         field: &ArchivedVec<T::Archived>,
         deserializer: &mut D,
     ) -> Result<HashSet<T>, D::Error> {
-        let mut result = HashSet::new();
+        let mut result = HashSet::with_capacity(field.len());
         for key in field.iter() {
             result.insert(key.deserialize(deserializer)?);
         }

--- a/rkyv_derive/Cargo.toml
+++ b/rkyv_derive/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2.workspace = true
-syn.workspace = true
+syn = { workspace = true, features = ["full"] }
 quote.workspace = true
 
 [features]

--- a/rkyv_derive/src/deserialize.rs
+++ b/rkyv_derive/src/deserialize.rs
@@ -53,7 +53,7 @@ fn derive_deserialize_impl(
             Fields::Named(ref fields) => {
                 let mut deserialize_where = where_clause.clone();
                 for field in fields.named.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     deserialize_where
@@ -94,7 +94,7 @@ fn derive_deserialize_impl(
             Fields::Unnamed(ref fields) => {
                 let mut deserialize_where = where_clause.clone();
                 for field in fields.unnamed.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     deserialize_where
@@ -150,7 +150,7 @@ fn derive_deserialize_impl(
                         for field in fields.named.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             deserialize_where
@@ -165,7 +165,7 @@ fn derive_deserialize_impl(
                         for field in fields.unnamed.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             deserialize_where

--- a/rkyv_derive/src/serde/receiver.rs
+++ b/rkyv_derive/src/serde/receiver.rs
@@ -155,7 +155,6 @@ impl ReplaceReceiver<'_> {
             }
 
             Type::Infer(_) | Type::Never(_) | Type::Verbatim(_) => {}
-
             _ => {}
         }
     }
@@ -187,12 +186,14 @@ impl ReplaceReceiver<'_> {
                 for arg in &mut arguments.args {
                     match arg {
                         GenericArgument::Type(arg) => self.visit_type_mut(arg),
-                        GenericArgument::Binding(arg) => {
+                        GenericArgument::AssocType(arg) => {
                             self.visit_type_mut(&mut arg.ty)
                         }
                         GenericArgument::Lifetime(_)
-                        | GenericArgument::Constraint(_)
-                        | GenericArgument::Const(_) => {}
+                        | GenericArgument::Const(_)
+                        | GenericArgument::AssocConst(_)
+                        | GenericArgument::Constraint(_) => {}
+                        _ => {}
                     }
                 }
             }
@@ -217,7 +218,8 @@ impl ReplaceReceiver<'_> {
             TypeParamBound::Trait(bound) => {
                 self.visit_path_mut(&mut bound.path)
             }
-            TypeParamBound::Lifetime(_) => {}
+            TypeParamBound::Lifetime(_) | TypeParamBound::Verbatim(_) => {}
+            _ => {}
         }
     }
 
@@ -241,7 +243,8 @@ impl ReplaceReceiver<'_> {
                             self.visit_type_param_bound_mut(bound);
                         }
                     }
-                    WherePredicate::Lifetime(_) | WherePredicate::Eq(_) => {}
+                    WherePredicate::Lifetime(_) => {}
+                    _ => {}
                 }
             }
         }

--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -59,7 +59,7 @@ fn derive_serialize_impl(
             Fields::Named(ref fields) => {
                 let mut serialize_where = where_clause.clone();
                 for field in fields.named.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     serialize_where
@@ -87,7 +87,7 @@ fn derive_serialize_impl(
             Fields::Unnamed(ref fields) => {
                 let mut serialize_where = where_clause.clone();
                 for field in fields.unnamed.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     serialize_where
@@ -131,7 +131,7 @@ fn derive_serialize_impl(
                         for field in fields.named.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             serialize_where
@@ -143,7 +143,7 @@ fn derive_serialize_impl(
                         for field in fields.unnamed.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             serialize_where

--- a/rkyv_derive/src/util.rs
+++ b/rkyv_derive/src/util.rs
@@ -1,18 +1,20 @@
 use proc_macro2::Ident;
 use syn::{
-    punctuated::Punctuated, Error, LitStr, Token, WhereClause, WherePredicate,
+    parse::{Parse, ParseStream},
+    token::Token as TokenTrait,
+    Error, LitStr, Token, WhereClause,
 };
 
 pub fn add_bounds(
     bounds: &LitStr,
     where_clause: &mut WhereClause,
 ) -> Result<(), Error> {
-    let clauses = bounds.parse_with(
-        Punctuated::<WherePredicate, Token![,]>::parse_terminated,
-    )?;
+    let clauses = bounds.parse_with(Vec::parse_terminated::<Token![,]>)?;
+
     for clause in clauses {
         where_clause.predicates.push(clause);
     }
+
     Ok(())
 }
 
@@ -22,4 +24,104 @@ pub fn strip_raw(ident: &Ident) -> String {
         .strip_prefix("r#")
         .map(ToString::to_string)
         .unwrap_or(as_string)
+}
+
+/// Revamping utility from [`Punctuated`] for the purpose of storing items
+/// more efficiently.
+///
+/// [`Punctuated`]: syn::punctuated::Punctuated
+pub trait PunctuatedExt<T> {
+    /// Parses one or more occurrences of `T` separated by punctuation of type
+    /// `P`, not accepting trailing punctuation.
+    ///
+    /// Parsing continues as long as punctuation `P` is present at the head of
+    /// the stream. This method returns upon parsing a `T` and observing that it
+    /// is not followed by a `P`, even if there are remaining tokens in the
+    /// stream.
+    fn parse_separated_nonempty<P: Parse + TokenTrait>(
+        input: ParseStream,
+    ) -> Result<Vec<T>, Error>
+    where
+        T: Parse,
+    {
+        Self::parse_separated_nonempty_with::<P>(input, T::parse)
+    }
+
+    /// Parses one or more occurrences of `T` using the given parse function,
+    /// separated by punctuation of type `P`, not accepting trailing
+    /// punctuation.
+    ///
+    /// Like [`parse_separated_nonempty`], may complete early without parsing
+    /// the entire content of this stream.
+    fn parse_separated_nonempty_with<P: Parse + TokenTrait>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Vec<T>, Error>;
+
+    /// Parses zero or more occurrences of `T` separated by punctuation of type
+    /// `P`, with optional trailing punctuation.
+    ///
+    /// Parsing continues until the end of this parse stream. The entire content
+    /// of this parse stream must consist of `T` and `P`.
+    fn parse_terminated<P: Parse>(input: ParseStream) -> Result<Vec<T>, Error>
+    where
+        T: Parse,
+    {
+        Self::parse_terminated_with::<P>(input, T::parse)
+    }
+
+    /// Parses zero or more occurrences of `T` using the given parse function,
+    /// separated by punctuation of type `P`, with optional trailing
+    /// punctuation.
+    ///
+    /// Like [`parse_terminated`], the entire content of this stream is expected
+    /// to be parsed.
+    fn parse_terminated_with<P: Parse>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Vec<T>, Error>;
+}
+
+impl<T> PunctuatedExt<T> for Vec<T> {
+    fn parse_separated_nonempty_with<P: Parse + TokenTrait>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Self, Error> {
+        let mut vec = Vec::new();
+
+        loop {
+            vec.push(parser(input)?);
+
+            if !P::peek(input.cursor()) {
+                break;
+            }
+
+            input.parse::<P>()?;
+        }
+
+        Ok(vec)
+    }
+
+    fn parse_terminated_with<P: Parse>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Self, Error> {
+        let mut vec = Vec::new();
+
+        loop {
+            if input.is_empty() {
+                break;
+            }
+
+            vec.push(parser(input)?);
+
+            if input.is_empty() {
+                break;
+            }
+
+            input.parse::<P>()?;
+        }
+
+        Ok(vec)
+    }
 }

--- a/rkyv_derive/src/with.rs
+++ b/rkyv_derive/src/with.rs
@@ -1,7 +1,6 @@
-use syn::{
-    parse_quote, punctuated::Punctuated, token::Comma, Error, Expr, Field,
-    Path, Type,
-};
+use syn::{parse_quote, Error, Expr, Field, Path, Token, Type};
+
+use crate::util::PunctuatedExt;
 
 #[inline]
 pub fn with<B, F: FnMut(B, &Type) -> B>(
@@ -13,9 +12,9 @@ pub fn with<B, F: FnMut(B, &Type) -> B>(
         .attrs
         .iter()
         .filter_map(|attr| {
-            if attr.path.is_ident("with") {
+            if attr.path().is_ident("with") {
                 Some(attr.parse_args_with(
-                    Punctuated::<Type, Comma>::parse_separated_nonempty,
+                    Vec::parse_separated_nonempty::<Token![,]>,
                 ))
             } else {
                 None


### PR DESCRIPTION
Mostly just copied from the `sync::Arc` and `TinyVec` implementations.

Unfortunately `Deserialize` can only be implemented for `triomphe::Arc` with `T: Sized`, but oh well. I'm unsure if any of the other `triomphe` types can be used with rkyv, they're kind of restrictive. 