### PR TITLE
PartialOrd fix for ArchivedVec.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ quote = "1.0"
 rend = { version = "0.5", git = "https://github.com/rkyv/rend", branch = "master", default-features = false }
 rkyv_derive = { version = "=0.8.0", path = "rkyv_derive" }
 seahash = "4.0"
-syn = "1.0"
+syn = "2.0"
 wasm-bindgen-test = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/rkyv/rkyv"
 
 [workspace.dependencies]
 bytecheck = { version = "0.7", default-features = false }
-hashbrown = "0.12"
+hashbrown = "0.14"
 proc-macro2 = "1.0"
 ptr_meta = { version = "0.2", default-features = false }
 quote = "1.0"

--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -49,6 +49,7 @@ strict = ["rkyv_derive/strict"]
 copy = ["rkyv_derive/copy"]
 copy_unsafe = []
 validation = ["alloc", "bytecheck", "rend/validation"]
+extra_traits = []
 
 # Crate support
 uuid = ["dep:uuid", "bytecheck?/uuid"]

--- a/rkyv/src/de/deserializers/alloc.rs
+++ b/rkyv/src/de/deserializers/alloc.rs
@@ -57,6 +57,14 @@ impl SharedDeserializeMap {
             shared_pointers: hash_map::HashMap::new(),
         }
     }
+
+    /// Wraps the given deserializer and adds shared memory support, with initial capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            shared_pointers: hash_map::HashMap::with_capacity(capacity),
+        }
+    }
 }
 
 impl fmt::Debug for SharedDeserializeMap {

--- a/rkyv/src/impls/alloc/vec.rs
+++ b/rkyv/src/impls/alloc/vec.rs
@@ -23,10 +23,18 @@ impl<T: PartialEq<U>, U> PartialEq<ArchivedVec<U>> for Vec<T> {
     }
 }
 
-impl<T: PartialOrd> PartialOrd<Vec<T>> for ArchivedVec<T> {
+impl<T: PartialOrd<U>, U> PartialOrd<Vec<U>> for ArchivedVec<T>
+{
     #[inline]
-    fn partial_cmp(&self, other: &Vec<T>) -> Option<cmp::Ordering> {
-        self.as_slice().partial_cmp(other.as_slice())
+    fn partial_cmp(&self, other: &Vec<U>) -> Option<cmp::Ordering> {
+        let min_len = self.len().min(other.len());
+        for i in 0..min_len {
+            match self[i].partial_cmp(&other[i]) {
+                Some(cmp::Ordering::Equal) => continue,
+                result => return result,
+            }
+        }
+        self.len().partial_cmp(&other.len())
     }
 }
 

--- a/rkyv/src/impls/tinyvec.rs
+++ b/rkyv/src/impls/tinyvec.rs
@@ -3,7 +3,7 @@ use crate::{
     vec::{ArchivedVec, VecResolver},
     Archive, Archived, Deserialize, Fallible, Serialize,
 };
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 use tinyvec::TinyVec;
 use tinyvec::{Array, ArrayVec, SliceVec};
 
@@ -93,7 +93,7 @@ impl<'s, T: Serialize<S>, S: ScratchSpace + Serializer + ?Sized> Serialize<S>
 
 // TinyVec
 
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 impl<A: Array> Archive for TinyVec<A>
 where
     A::Item: Archive,
@@ -112,7 +112,7 @@ where
     }
 }
 
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 impl<A: Array, S: ScratchSpace + Serializer + ?Sized> Serialize<S>
     for TinyVec<A>
 where
@@ -127,7 +127,7 @@ where
     }
 }
 
-#[cfg(feature = "tinyvec_alloc")]
+#[cfg(all(feature = "tinyvec", feature = "alloc"))]
 impl<A: Array, D: Fallible + ?Sized> Deserialize<TinyVec<A>, D>
     for ArchivedVec<Archived<A::Item>>
 where
@@ -191,7 +191,7 @@ mod tests {
         assert_eq!(archived.as_slice(), &[10, 20, 40, 80]);
     }
 
-    #[cfg(feature = "tinyvec_alloc")]
+    #[cfg(all(feature = "tinyvec", feature = "alloc"))]
     #[test]
     fn tiny_vec() {
         use crate::ser::serializers::AllocSerializer;

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -94,8 +94,8 @@
 //! Support for each of these crates can be enabled with a feature of the same name. Additionally,
 //! the following external crate features are available:
 //!
-//! - `tinyvec_alloc`: Supports types behind the `alloc` feature in `tinyvec`.
-//! - `uuid_std`: Enables the `std` feature in `uuid`.
+//! - `alloc` with `tinyvec/alloc`: Supports types behind the `alloc` feature in `tinyvec`.
+//! - `std` with `uuid/std`: Enables the `std` feature in `uuid`.
 //!
 //! ## Examples
 //!

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -41,7 +41,7 @@
 //! support custom contextual types.
 //!
 //! Finally, rkyv makes it possible to serialize trait objects and use them *as trait objects*
-//! without deserialization. See the `archive_dyn` crate for more details.
+//! without deserialization. See the `rkyv_dyn` crate for more details.
 //!
 //! ## Tradeoffs
 //!

--- a/rkyv/src/option.rs
+++ b/rkyv/src/option.rs
@@ -194,6 +194,32 @@ impl<T: PartialOrd> PartialOrd for ArchivedOption<T> {
     }
 }
 
+#[cfg(feature = "extra_traits")]
+impl<T, U: PartialOrd<T>> PartialOrd<Option<T>> for ArchivedOption<U> {
+    #[inline]
+    fn partial_cmp(&self, other: &Option<T>) -> Option<cmp::Ordering> {
+        match (self, other) {
+            (ArchivedOption::None, None) => Some(cmp::Ordering::Equal),
+            (ArchivedOption::None, Some(_)) => Some(cmp::Ordering::Less),
+            (ArchivedOption::Some(_), None) => Some(cmp::Ordering::Greater),
+            (ArchivedOption::Some(self_value), Some(other_value)) => self_value.partial_cmp(other_value),
+        }
+    }
+}
+
+#[cfg(feature = "extra_traits")]
+impl<T: PartialOrd<U>, U> PartialOrd<ArchivedOption<T>> for Option<U> {
+    #[inline]
+    fn partial_cmp(&self, other: &ArchivedOption<T>) -> Option<cmp::Ordering> {
+        match (self, other) {
+            (None, ArchivedOption::None) => Some(cmp::Ordering::Equal),
+            (None, ArchivedOption::Some(_)) => Some(cmp::Ordering::Less),
+            (Some(_), ArchivedOption::None) => Some(cmp::Ordering::Greater),
+            (Some(self_value), ArchivedOption::Some(other_value)) => other_value.partial_cmp(self_value).map(|ord| ord.reverse()),
+        }
+    }
+}
+
 impl<T, U: PartialEq<T>> PartialEq<Option<T>> for ArchivedOption<U> {
     #[inline]
     fn eq(&self, other: &Option<T>) -> bool {
@@ -279,5 +305,30 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.next()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ArchivedOption;
+    use core::cmp::Ordering;
+
+    #[test]
+    #[cfg(feature = "extra_traits")]
+    fn partial_ord_option() {
+        let a: ArchivedOption<u8> = ArchivedOption::Some(42);
+        let b = Some(42);
+        assert_eq!(Some(Ordering::Equal), a.partial_cmp(&b));
+        assert_eq!(Some(Ordering::Equal), b.partial_cmp(&a));
+
+        let a: ArchivedOption<u8> = ArchivedOption::Some(1);
+        let b = Some(2);
+        assert_eq!(Some(Ordering::Less), a.partial_cmp(&b));
+        assert_eq!(Some(Ordering::Greater), b.partial_cmp(&a));
+
+        let a: ArchivedOption<u8> = ArchivedOption::Some(2);
+        let b = Some(1);
+        assert_eq!(Some(Ordering::Greater), a.partial_cmp(&b));
+        assert_eq!(Some(Ordering::Less), b.partial_cmp(&a));
     }
 }

--- a/rkyv/src/ser/serializers/alloc.rs
+++ b/rkyv/src/ser/serializers/alloc.rs
@@ -400,6 +400,14 @@ impl SharedSerializeMap {
             shared_resolvers: hash_map::HashMap::new(),
         }
     }
+
+    /// Creates a new shared registry map with initial capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            shared_resolvers: hash_map::HashMap::with_capacity(capacity),
+        }
+    }
 }
 
 impl Default for SharedSerializeMap {

--- a/rkyv/src/util/mod.rs
+++ b/rkyv/src/util/mod.rs
@@ -43,7 +43,7 @@ fn check_alignment<T>(ptr: *const u8) {
         concat!(
             "unaligned buffer, expected alignment {} but found alignment {}\n",
             "help: rkyv requires byte buffers to be aligned to access the data inside.\n",
-            "      Using an ALignedVec or manually aligning your data with #[align(...)]\n",
+            "      Using an AlignedVec or manually aligning your data with #[align(...)]\n",
             "      may resolve this issue.",
         ),
         expect_align,

--- a/rkyv/src/validation/validators/mod.rs
+++ b/rkyv/src/validation/validators/mod.rs
@@ -69,6 +69,15 @@ impl<'a> DefaultValidator<'a> {
             shared: SharedValidator::new(),
         }
     }
+
+    /// Create a new validator from a byte range with specific capacity.
+    #[inline]
+    pub fn with_capacity(bytes: &'a [u8], capacity: usize) -> Self {
+        Self {
+            archive: ArchiveValidator::new(bytes),
+            shared: SharedValidator::with_capacity(capacity),
+        }
+    }
 }
 
 impl<'a> Fallible for DefaultValidator<'a> {

--- a/rkyv/src/validation/validators/shared.rs
+++ b/rkyv/src/validation/validators/shared.rs
@@ -69,6 +69,14 @@ impl SharedValidator {
             shared: HashMap::new(),
         }
     }
+
+    /// Shared memory validator with specific capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            shared: HashMap::with_capacity(capacity),
+        }
+    }
 }
 
 impl Default for SharedValidator {

--- a/rkyv/src/with/impls/std.rs
+++ b/rkyv/src/with/impls/std.rs
@@ -280,7 +280,7 @@ where
         field: &ArchivedVec<Entry<K::Archived, V::Archived>>,
         deserializer: &mut D,
     ) -> Result<HashMap<K, V>, D::Error> {
-        let mut result = HashMap::new();
+        let mut result = HashMap::with_capacity(field.len());
         for entry in field.iter() {
             result.insert(
                 entry.key.deserialize(deserializer)?,
@@ -331,7 +331,7 @@ where
         field: &ArchivedVec<T::Archived>,
         deserializer: &mut D,
     ) -> Result<HashSet<T>, D::Error> {
-        let mut result = HashSet::new();
+        let mut result = HashSet::with_capacity(field.len());
         for key in field.iter() {
             result.insert(key.deserialize(deserializer)?);
         }

--- a/rkyv_derive/Cargo.toml
+++ b/rkyv_derive/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2.workspace = true
-syn.workspace = true
+syn = { workspace = true, features = ["full"] }
 quote.workspace = true
 
 [features]

--- a/rkyv_derive/src/deserialize.rs
+++ b/rkyv_derive/src/deserialize.rs
@@ -53,7 +53,7 @@ fn derive_deserialize_impl(
             Fields::Named(ref fields) => {
                 let mut deserialize_where = where_clause.clone();
                 for field in fields.named.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     deserialize_where
@@ -94,7 +94,7 @@ fn derive_deserialize_impl(
             Fields::Unnamed(ref fields) => {
                 let mut deserialize_where = where_clause.clone();
                 for field in fields.unnamed.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     deserialize_where
@@ -150,7 +150,7 @@ fn derive_deserialize_impl(
                         for field in fields.named.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             deserialize_where
@@ -165,7 +165,7 @@ fn derive_deserialize_impl(
                         for field in fields.unnamed.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             deserialize_where

--- a/rkyv_derive/src/serde/receiver.rs
+++ b/rkyv_derive/src/serde/receiver.rs
@@ -155,7 +155,6 @@ impl ReplaceReceiver<'_> {
             }
 
             Type::Infer(_) | Type::Never(_) | Type::Verbatim(_) => {}
-
             _ => {}
         }
     }
@@ -187,12 +186,14 @@ impl ReplaceReceiver<'_> {
                 for arg in &mut arguments.args {
                     match arg {
                         GenericArgument::Type(arg) => self.visit_type_mut(arg),
-                        GenericArgument::Binding(arg) => {
+                        GenericArgument::AssocType(arg) => {
                             self.visit_type_mut(&mut arg.ty)
                         }
                         GenericArgument::Lifetime(_)
-                        | GenericArgument::Constraint(_)
-                        | GenericArgument::Const(_) => {}
+                        | GenericArgument::Const(_)
+                        | GenericArgument::AssocConst(_)
+                        | GenericArgument::Constraint(_) => {}
+                        _ => {}
                     }
                 }
             }
@@ -217,7 +218,8 @@ impl ReplaceReceiver<'_> {
             TypeParamBound::Trait(bound) => {
                 self.visit_path_mut(&mut bound.path)
             }
-            TypeParamBound::Lifetime(_) => {}
+            TypeParamBound::Lifetime(_) | TypeParamBound::Verbatim(_) => {}
+            _ => {}
         }
     }
 
@@ -241,7 +243,8 @@ impl ReplaceReceiver<'_> {
                             self.visit_type_param_bound_mut(bound);
                         }
                     }
-                    WherePredicate::Lifetime(_) | WherePredicate::Eq(_) => {}
+                    WherePredicate::Lifetime(_) => {}
+                    _ => {}
                 }
             }
         }

--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -59,7 +59,7 @@ fn derive_serialize_impl(
             Fields::Named(ref fields) => {
                 let mut serialize_where = where_clause.clone();
                 for field in fields.named.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     serialize_where
@@ -87,7 +87,7 @@ fn derive_serialize_impl(
             Fields::Unnamed(ref fields) => {
                 let mut serialize_where = where_clause.clone();
                 for field in fields.unnamed.iter().filter(|f| {
-                    !f.attrs.iter().any(|a| a.path.is_ident("omit_bounds"))
+                    !f.attrs.iter().any(|a| a.path().is_ident("omit_bounds"))
                 }) {
                     let ty = with_ty(field)?;
                     serialize_where
@@ -131,7 +131,7 @@ fn derive_serialize_impl(
                         for field in fields.named.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             serialize_where
@@ -143,7 +143,7 @@ fn derive_serialize_impl(
                         for field in fields.unnamed.iter().filter(|f| {
                             !f.attrs
                                 .iter()
-                                .any(|a| a.path.is_ident("omit_bounds"))
+                                .any(|a| a.path().is_ident("omit_bounds"))
                         }) {
                             let ty = with_ty(field)?;
                             serialize_where

--- a/rkyv_derive/src/util.rs
+++ b/rkyv_derive/src/util.rs
@@ -1,18 +1,20 @@
 use proc_macro2::Ident;
 use syn::{
-    punctuated::Punctuated, Error, LitStr, Token, WhereClause, WherePredicate,
+    parse::{Parse, ParseStream},
+    token::Token as TokenTrait,
+    Error, LitStr, Token, WhereClause,
 };
 
 pub fn add_bounds(
     bounds: &LitStr,
     where_clause: &mut WhereClause,
 ) -> Result<(), Error> {
-    let clauses = bounds.parse_with(
-        Punctuated::<WherePredicate, Token![,]>::parse_terminated,
-    )?;
+    let clauses = bounds.parse_with(Vec::parse_terminated::<Token![,]>)?;
+
     for clause in clauses {
         where_clause.predicates.push(clause);
     }
+
     Ok(())
 }
 
@@ -22,4 +24,104 @@ pub fn strip_raw(ident: &Ident) -> String {
         .strip_prefix("r#")
         .map(ToString::to_string)
         .unwrap_or(as_string)
+}
+
+/// Revamping utility from [`Punctuated`] for the purpose of storing items
+/// more efficiently.
+///
+/// [`Punctuated`]: syn::punctuated::Punctuated
+pub trait PunctuatedExt<T> {
+    /// Parses one or more occurrences of `T` separated by punctuation of type
+    /// `P`, not accepting trailing punctuation.
+    ///
+    /// Parsing continues as long as punctuation `P` is present at the head of
+    /// the stream. This method returns upon parsing a `T` and observing that it
+    /// is not followed by a `P`, even if there are remaining tokens in the
+    /// stream.
+    fn parse_separated_nonempty<P: Parse + TokenTrait>(
+        input: ParseStream,
+    ) -> Result<Vec<T>, Error>
+    where
+        T: Parse,
+    {
+        Self::parse_separated_nonempty_with::<P>(input, T::parse)
+    }
+
+    /// Parses one or more occurrences of `T` using the given parse function,
+    /// separated by punctuation of type `P`, not accepting trailing
+    /// punctuation.
+    ///
+    /// Like [`parse_separated_nonempty`], may complete early without parsing
+    /// the entire content of this stream.
+    fn parse_separated_nonempty_with<P: Parse + TokenTrait>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Vec<T>, Error>;
+
+    /// Parses zero or more occurrences of `T` separated by punctuation of type
+    /// `P`, with optional trailing punctuation.
+    ///
+    /// Parsing continues until the end of this parse stream. The entire content
+    /// of this parse stream must consist of `T` and `P`.
+    fn parse_terminated<P: Parse>(input: ParseStream) -> Result<Vec<T>, Error>
+    where
+        T: Parse,
+    {
+        Self::parse_terminated_with::<P>(input, T::parse)
+    }
+
+    /// Parses zero or more occurrences of `T` using the given parse function,
+    /// separated by punctuation of type `P`, with optional trailing
+    /// punctuation.
+    ///
+    /// Like [`parse_terminated`], the entire content of this stream is expected
+    /// to be parsed.
+    fn parse_terminated_with<P: Parse>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Vec<T>, Error>;
+}
+
+impl<T> PunctuatedExt<T> for Vec<T> {
+    fn parse_separated_nonempty_with<P: Parse + TokenTrait>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Self, Error> {
+        let mut vec = Vec::new();
+
+        loop {
+            vec.push(parser(input)?);
+
+            if !P::peek(input.cursor()) {
+                break;
+            }
+
+            input.parse::<P>()?;
+        }
+
+        Ok(vec)
+    }
+
+    fn parse_terminated_with<P: Parse>(
+        input: ParseStream,
+        parser: fn(ParseStream) -> Result<T, Error>,
+    ) -> Result<Self, Error> {
+        let mut vec = Vec::new();
+
+        loop {
+            if input.is_empty() {
+                break;
+            }
+
+            vec.push(parser(input)?);
+
+            if input.is_empty() {
+                break;
+            }
+
+            input.parse::<P>()?;
+        }
+
+        Ok(vec)
+    }
 }

--- a/rkyv_derive/src/with.rs
+++ b/rkyv_derive/src/with.rs
@@ -1,7 +1,6 @@
-use syn::{
-    parse_quote, punctuated::Punctuated, token::Comma, Error, Expr, Field,
-    Path, Type,
-};
+use syn::{parse_quote, Error, Expr, Field, Path, Token, Type};
+
+use crate::util::PunctuatedExt;
 
 #[inline]
 pub fn with<B, F: FnMut(B, &Type) -> B>(
@@ -13,9 +12,9 @@ pub fn with<B, F: FnMut(B, &Type) -> B>(
         .attrs
         .iter()
         .filter_map(|attr| {
-            if attr.path.is_ident("with") {
+            if attr.path().is_ident("with") {
                 Some(attr.parse_args_with(
-                    Punctuated::<Type, Comma>::parse_separated_nonempty,
+                    Vec::parse_separated_nonempty::<Token![,]>,
                 ))
             } else {
                 None


### PR DESCRIPTION
Without it, I couldn't get e.g., this to compile since it couldn't compare `Vec<String>` with `ArchivedVec<ArchivedString>`:

```
#[derive(Debug, Clone, SizeOf, Archive, Serialize, Deserialize)]
#[archive_attr(derive(Clone, Ord, Eq, PartialEq, PartialOrd))]
#[archive(compare(PartialEq, PartialOrd))]
pub struct PersonalNetworkGkgEntry {
    pub people: Vec<String>,
}
```

(FYI I hope that this partial_ord impl is actually correct since I haven't written any PartialOrd for slices/vectors before so definitely good to double check :O)