### PR TITLE
Corrected typos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ proc-macro2 = "1.0"
 ptr_meta = { version = "0.3.0-pre1", default-features = false }
 quote = "1.0"
 rend = { version = "0.5.0-pre6", default-features = false }
-rancor = { version = "0.1.0-pre8", deafult-features = false }
+rancor = { version = "0.1.0-pre8", default-features = false }
 rkyv = { version = "0.8.0-pre1", default-features = false, path = "rkyv" }
 rkyv_dyn = { version = "0.8.0-pre1", path = "rkyv_dyn" }
 # TODO: replace with a more performant cross-platform hashing algorithm

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -196,7 +196,7 @@ use crate::{
 
 #[cfg(not(any(feature = "little_endian", feature = "big_endian")))]
 core::compiler_error!(
-    "\"litle_endian\" or \"big_endian\" must be an enabled feature"
+    "\"little_endian\" or \"big_endian\" must be an enabled feature"
 );
 
 #[cfg(all(feature = "little_endian", feature = "big_endian"))]

--- a/rkyv/src/util/aligned_vec.rs
+++ b/rkyv/src/util/aligned_vec.rs
@@ -269,7 +269,7 @@ impl AlignedVec {
     /// ```
     /// use rkyv::AlignedVec;
     ///
-    /// // Allocate vecotr big enough for 4 bytes.
+    /// // Allocate vector big enough for 4 bytes.
     /// let size = 4;
     /// let mut x = AlignedVec::with_capacity(size);
     /// let x_ptr = x.as_mut_ptr();

--- a/rkyv/src/vec/mod.rs
+++ b/rkyv/src/vec/mod.rs
@@ -71,7 +71,7 @@ impl<T> ArchivedVec<T> {
     // This method can go away once pinned slices have indexing support
     // https://github.com/rust-lang/rust/pull/78370
 
-    /// Gets the element at the given index ot this archived vec as a pinned mutable reference.
+    /// Gets the element at the given index to this archived vec as a pinned mutable reference.
     #[inline]
     pub fn index_pin<I>(
         self: Pin<&mut Self>,

--- a/rkyv/src/vec/raw.rs
+++ b/rkyv/src/vec/raw.rs
@@ -55,7 +55,7 @@ impl<T> RawArchivedVec<T> {
     // This method can go away once pinned slices have indexing support
     // https://github.com/rust-lang/rust/pull/78370
 
-    /// Gets the element at the given index ot this archived vec as a pinned mutable reference.
+    /// Gets the element at the given index to this archived vec as a pinned mutable reference.
     #[inline]
     pub fn index_pin<I>(
         self: Pin<&mut Self>,


### PR DESCRIPTION
found with https://github.com/crate-ci/typos