### PR TITLE
PartialOrd fix for ArchivedVec.

### DIFF
--- a/rkyv/src/impls/alloc/vec.rs
+++ b/rkyv/src/impls/alloc/vec.rs
@@ -24,10 +24,18 @@ impl<T: PartialEq<U>, U> PartialEq<ArchivedVec<U>> for Vec<T> {
     }
 }
 
-impl<T: PartialOrd> PartialOrd<Vec<T>> for ArchivedVec<T> {
+impl<T: PartialOrd<U>, U> PartialOrd<Vec<U>> for ArchivedVec<T>
+{
     #[inline]
-    fn partial_cmp(&self, other: &Vec<T>) -> Option<cmp::Ordering> {
-        self.as_slice().partial_cmp(other.as_slice())
+    fn partial_cmp(&self, other: &Vec<U>) -> Option<cmp::Ordering> {
+        let min_len = self.len().min(other.len());
+        for i in 0..min_len {
+            match self[i].partial_cmp(&other[i]) {
+                Some(cmp::Ordering::Equal) => continue,
+                result => return result,
+            }
+        }
+        self.len().partial_cmp(&other.len())
     }
 }
 


### PR DESCRIPTION
Without it, I couldn't get e.g., this to compile since it couldn't compare Vec<String> with ArchivedVec<ArchivedString>:

```
#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
#[archive_attr(derive(Clone, Ord, Eq, PartialEq, PartialOrd))]
#[archive(compare(PartialEq, PartialOrd))]
pub struct PersonalNetworkGkgEntry {
    pub people: Vec<String>,
}
```

(FYI I hope that this partial_ord impl is actually correct since I haven't written any PartialOrd for slices/vectors before so definitely good to double check :O)
