### PR TITLE
Add `Cloned` wrapper for `Arc` and `Rc`

### DIFF
--- a/rkyv/src/with/impls/alloc.rs
+++ b/rkyv/src/with/impls/alloc.rs
@@ -11,6 +11,8 @@ use std::{
     borrow::Cow,
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
+    rc::Rc,
+    sync::Arc,
 };
 
 use rancor::Fallible;
@@ -23,7 +25,7 @@ use crate::{
     string::{ArchivedString, StringResolver},
     vec::{ArchivedVec, VecResolver},
     with::{
-        ArchiveWith, AsOwned, AsVec, BoxedInline, CopyOptimize,
+        ArchiveWith, AsOwned, AsVec, BoxedInline, Cloned, CopyOptimize,
         DeserializeWith, Map, Niche, SerializeWith, With,
     },
     Archive, ArchiveUnsized, ArchivedMetadata, Deserialize, DeserializeUnsized,
@@ -694,3 +696,69 @@ where
 //         Ok(result)
 //     }
 // }
+
+// Cloned
+
+impl<T: Archive> ArchiveWith<Arc<T>> for Cloned {
+    type Archived = T::Archived;
+    type Resolver = T::Resolver;
+
+    unsafe fn resolve_with(
+        x: &Arc<T>,
+        pos: usize,
+        resolver: Self::Resolver,
+        archived: *mut Self::Archived,
+    ) {
+        x.as_ref().resolve(pos, resolver, archived)
+    }
+}
+
+impl<T: Serialize<S>, S: Fallible + ?Sized> SerializeWith<Arc<T>, S>
+    for Cloned
+{
+    fn serialize_with(
+        x: &Arc<T>,
+        s: &mut S,
+    ) -> Result<Self::Resolver, S::Error> {
+        x.as_ref().serialize(s)
+    }
+}
+
+impl<A: Deserialize<T, D>, T, D: Fallible + ?Sized>
+    DeserializeWith<A, Arc<T>, D> for Cloned
+{
+    fn deserialize_with(x: &A, d: &mut D) -> Result<Arc<T>, D::Error> {
+        Ok(Arc::new(A::deserialize(x, d)?))
+    }
+}
+
+impl<T: Archive> ArchiveWith<Rc<T>> for Cloned {
+    type Archived = T::Archived;
+    type Resolver = T::Resolver;
+
+    unsafe fn resolve_with(
+        x: &Rc<T>,
+        pos: usize,
+        resolver: Self::Resolver,
+        archived: *mut Self::Archived,
+    ) {
+        x.as_ref().resolve(pos, resolver, archived)
+    }
+}
+
+impl<T: Serialize<S>, S: Fallible + ?Sized> SerializeWith<Rc<T>, S> for Cloned {
+    fn serialize_with(
+        x: &Rc<T>,
+        s: &mut S,
+    ) -> Result<Self::Resolver, S::Error> {
+        x.as_ref().serialize(s)
+    }
+}
+
+impl<A: Deserialize<T, D>, T, D: Fallible + ?Sized> DeserializeWith<A, Rc<T>, D>
+    for Cloned
+{
+    fn deserialize_with(x: &A, d: &mut D) -> Result<Rc<T>, D::Error> {
+        Ok(Rc::new(A::deserialize(x, d)?))
+    }
+}

--- a/rkyv/src/with/mod.rs
+++ b/rkyv/src/with/mod.rs
@@ -741,3 +741,7 @@ pub struct Unsafe;
 /// ```
 #[derive(Debug)]
 pub struct Skip;
+
+/// A wrapper that clones the contents of `Arc` and `Rc` pointers.
+#[derive(Debug)]
+pub struct Cloned;


### PR DESCRIPTION
This wrapper (usable via `#[with(Cloned)]`) serializes `Arc<T>`/`Rc<T>` using the serializer for `T`. Conversely, during deserialization it calls `Arc::new()`/`Rc::new()`