### PR TITLE
Implement CheckBytes on ArchivedOptionBox and ArchivedOptionNonZeroN, plus `ArchivedOptionNonZeroN::take()`

### DIFF
--- a/rkyv/src/boxed.rs
+++ b/rkyv/src/boxed.rs
@@ -22,7 +22,7 @@ use crate::{
 )]
 #[repr(transparent)]
 pub struct ArchivedBox<T: ArchivePointee + ?Sized> {
-    ptr: RelPtr<T>,
+    pub(crate) ptr: RelPtr<T>,
 }
 
 impl<T: ArchivePointee + ?Sized> ArchivedBox<T> {

--- a/rkyv/src/boxed.rs
+++ b/rkyv/src/boxed.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// An archived [`Box`].
 ///
-/// This is a thin wrapper around a [`RelPtr`] to the archived type.
+/// This is a thin `#[repr(transparent)]` wrapper around a [`RelPtr`] to the archived type.
 #[derive(Portable)]
 #[archive(crate)]
 #[cfg_attr(
@@ -22,7 +22,7 @@ use crate::{
 )]
 #[repr(transparent)]
 pub struct ArchivedBox<T: ArchivePointee + ?Sized> {
-    pub(crate) ptr: RelPtr<T>,
+    ptr: RelPtr<T>,
 }
 
 impl<T: ArchivePointee + ?Sized> ArchivedBox<T> {

--- a/rkyv/src/niche/option_box.rs
+++ b/rkyv/src/niche/option_box.rs
@@ -40,11 +40,10 @@ const _: () = {
             value: *const Self,
             context: &mut C,
         ) -> Result<(), C::Error> {
-            // bypass `ArchivedBox::check_bytes` in favor of `RelPtr::check_bytes`
-            CheckBytes::check_bytes(
-                core::ptr::addr_of!((*value).inner.ptr),
-                context,
-            )?;
+            // bypass `ArchivedBox::check_bytes` in favor of `RelPtr::check_bytes`.
+            // both ArchivedOptionBox and ArchivedBox are transparent to the RelPtr,
+            // so casting to RelPtr is safe.
+            RelPtr::check_bytes(value.cast(), context)?;
 
             // verify with null check
             Verify::verify(unsafe { &*value }, context)

--- a/rkyv/src/niche/option_box.rs
+++ b/rkyv/src/niche/option_box.rs
@@ -46,7 +46,7 @@ const _: () = {
             RelPtr::check_bytes(value.cast(), context)?;
 
             // verify with null check
-            Verify::verify(unsafe { &*value }, context)
+            Self::verify(unsafe { &*value }, context)
         }
     }
 
@@ -60,10 +60,10 @@ const _: () = {
         #[inline]
         fn verify(&self, context: &mut C) -> Result<(), C::Error> {
             if self.inner.is_null() {
-                return Ok(());
+                Ok(()) // null pointer doesn't need to be checked
+            } else {
+                self.inner.verify(context)
             }
-
-            self.inner.verify(context)
         }
     }
 };
@@ -292,7 +292,7 @@ mod tests {
         for value in [Some(128.into()), None] {
             let test = Test { value };
             let bytes = crate::to_bytes::<Test, 256, Failure>(&test).unwrap();
-            assert_eq!(bytes.len(), 4 + test.value.is_some() as usize * 16);
+            assert_eq!(bytes.len(), 4 + test.value.is_some() as usize * 16); // ptr + value?
 
             let ar = match crate::access::<Archived<Test>, Failure>(&bytes) {
                 Ok(archived) => archived,

--- a/rkyv/src/niche/option_nonzero.rs
+++ b/rkyv/src/niche/option_nonzero.rs
@@ -36,6 +36,7 @@ macro_rules! impl_archived_option_nonzero {
             }
 
             #[doc = concat!("Converts to an `Option<&Archived<", stringify!($nz), ">>`")]
+            #[inline]
             pub fn as_ref(&self) -> Option<&Archived<$nz>> {
                 if self.inner != 0 {
                     let as_nonzero = unsafe {
@@ -50,6 +51,7 @@ macro_rules! impl_archived_option_nonzero {
             }
 
             #[doc = concat!("Converts to an `Option<&mut Archived<", stringify!($nz), ">>`")]
+            #[inline]
             pub fn as_mut(&mut self) -> Option<&mut Archived<$nz>> {
                 if self.inner != 0 {
                     let as_nonzero = unsafe {
@@ -58,6 +60,17 @@ macro_rules! impl_archived_option_nonzero {
                         &mut *(&mut self.inner as *mut _ as *mut Archived<$nz>)
                     };
                     Some(as_nonzero)
+                } else {
+                    None
+                }
+            }
+
+            /// Takes the value out of the option, leaving a `None` in its place.
+            #[inline]
+            pub fn take(&mut self) -> Option<Archived<$nz>> {
+                if self.inner != 0 {
+                    #[allow(clippy::transmute_int_to_non_zero)] // SAFETY: self.inner is nonzero
+                    Some(unsafe { core::mem::transmute(core::mem::replace(&mut self.inner, 0.into())) })
                 } else {
                     None
                 }

--- a/rkyv/src/niche/option_nonzero.rs
+++ b/rkyv/src/niche/option_nonzero.rs
@@ -17,6 +17,7 @@ macro_rules! impl_archived_option_nonzero {
         #[derive(Portable)]
         #[archive(crate)]
         #[repr(transparent)]
+        #[cfg_attr(feature = "bytecheck", derive(bytecheck::CheckBytes))]
         pub struct $ar {
             inner: Archived<$ne>,
         }


### PR DESCRIPTION
As the title says.

Closes #474
Closes #368

The `ArchivedOptionNonZeroN::take()` is a bit extra, but I was in the file.