### PR TITLE
Added range and reversability to ArchiveBTreeMap iterators

### DIFF
--- a/rkyv/src/collections/btree_map/mod.rs
+++ b/rkyv/src/collections/btree_map/mod.rs
@@ -934,7 +934,7 @@ impl<'a, K, V> Iterator for RawIter<'a, K, V> {
         match &self.run {
             RawIterRun::RunningExact { remaining, .. } => (*remaining, Some(*remaining)),
             RawIterRun::Running { .. } | RawIterRun::RunningInit { .. } => (0, None),
-            RawIterRun::LastOne { .. } => (1, Some(1)),
+            RawIterRun::LastOne { .. } => (0, Some(1)),
             RawIterRun::Finished => (0, Some(0)),
         }
     }

--- a/rkyv/src/collections/btree_map/mod.rs
+++ b/rkyv/src/collections/btree_map/mod.rs
@@ -418,7 +418,7 @@ impl<K, V> ArchivedBTreeMap<K, V> {
     }
 
     /// Constructs a double-ended iterator over a sub-range of elements in the map.
-    /// #[inline]
+    #[inline]
     pub fn range<R>(&self, range: R) -> Iter<'_, K, V>
     where
         K: Ord,
@@ -987,8 +987,7 @@ where K: Ord {
     }
 }
 
-impl<'a, K, V> FusedIterator for RawIter<'a, K, V>
-where K: Ord {}
+impl<'a, K, V> FusedIterator for RawIter<'a, K, V> {}
 
 /// An iterator over the key-value pairs of an archived B-tree map.
 pub struct Iter<'a, K, V> {

--- a/rkyv/src/collections/btree_map/mod.rs
+++ b/rkyv/src/collections/btree_map/mod.rs
@@ -522,7 +522,7 @@ where K: Ord {
 
                 let mut next_classified: ClassifiedNode<'a, K, V> = next.classify();
                 if let ClassifiedNode::Leaf(leaf) = next_classified {
-                    if std::ptr::addr_eq(leaf, cur.0) {
+                    if addr_eq(leaf, cur.0) {
                         next = match scan {
                             Ok(0) => unsafe { &*inner.header.ptr.as_ptr() },
                             Ok(i) => unsafe { &*inner.tail[i - 1].ptr.as_ptr() },
@@ -536,13 +536,18 @@ where K: Ord {
                 current = next_classified;
             }
             ClassifiedNode::Leaf(leaf) => {
-                if std::ptr::addr_eq(leaf, cur.0) {
+                if addr_eq(leaf, cur.0) {
                     return None;
                 }
                 return Some((leaf, leaf.tail.len() - 1));
             }
         }
     }
+}
+
+#[inline(always)]
+fn addr_eq<T: ?Sized, U: ?Sized>(p: *const T, q: *const U) -> bool {
+    (p as *const ()) == (q as *const ())
 }
 
 #[cfg(feature = "alloc")]
@@ -910,7 +915,7 @@ impl<'a, K, V> Iterator for RawIter<'a, K, V> {
                         Some(a) => a,
                         None => *first,
                     };
-                    if std::ptr::addr_eq(cur.0, last.0) && cur.1 == last.1 {
+                    if addr_eq(cur.0, last.0) && cur.1 == last.1 {
                         self.run = RawIterRun::LastOne { cur: *cur };
                     }
                     Some(ret)
@@ -947,7 +952,7 @@ where K: Ord {
             return match &mut self.run {
                 RawIterRun::RunningExact { cur, .. } => {
                     match (self.tree.first(), self.tree.last()) {
-                        (Some(first), Some(last)) if std::ptr::addr_eq(cur.0, first.0) && cur.1 == first.1 => {
+                        (Some(first), Some(last)) if addr_eq(cur.0, first.0) && cur.1 == first.1 => {
                             self.run = RawIterRun::Running { first, cur: last, last };
                             continue;
                         },
@@ -967,7 +972,7 @@ where K: Ord {
                         Some(a) => a,
                         None => *last,
                     };
-                    if std::ptr::addr_eq(cur.0, first.0) && cur.1 == first.1 {
+                    if addr_eq(cur.0, first.0) && cur.1 == first.1 {
                         self.run = RawIterRun::LastOne { cur: *cur };
                     }
                     Some(ret)


### PR DESCRIPTION
This is really needed to do anything useful with the BTreeMap rather than just an expensive sorter, having the ability to use ranges in Log(O(n)) time allows for interesting use-cases such as very fast loading of BTreeMaps which can then be used by rendering engines immediately with memory copies or reading the entire tree. Also highly useful for very optimized databases that would need to do range scans on file backed data.

- Regression tested locally
- Added unit tests
- Maximum backwards compatibility
- Performance tweaks for fast 
- Retained hint size on forward iterator
- Removed ExactSizeIterator (this won't work with the ranges)

P.s. This was much harder to write than I thought it would be....oh well!