### PR TITLE
Fix partial ord

### DIFF
--- a/rkyv_derive/src/archive/enum.rs
+++ b/rkyv_derive/src/archive/enum.rs
@@ -732,7 +732,7 @@ fn generate_partial_ord_impl(
                             #(
                                 match #other_fields.partial_cmp(#self_fields) {
                                     Some(::core::cmp::Ordering::Equal) => (),
-                                    cmp => return cmp,
+                                    cmp => return cmp.map(::core::cmp::Ordering::reverse),
                                 }
                             )*
                             Some(::core::cmp::Ordering::Equal)
@@ -749,7 +749,7 @@ fn generate_partial_ord_impl(
                             #(
                                 match #other_fields.partial_cmp(#self_fields) {
                                     Some(::core::cmp::Ordering::Equal) => (),
-                                    cmp => return cmp,
+                                    cmp => return cmp.map(::core::cmp::Ordering::reverse),
                                 }
                             )*
                             Some(::core::cmp::Ordering::Equal)

--- a/rkyv_derive/src/archive/struct.rs
+++ b/rkyv_derive/src/archive/struct.rs
@@ -422,7 +422,7 @@ fn generate_partial_ord_impl(
                 #(
                     match other.#members.partial_cmp(&self.#members) {
                         Some(::core::cmp::Ordering::Equal) => (),
-                        x => return x.map(|o| o.reverse()),
+                        x => return x.map(::core::cmp::Ordering::reverse),
                     }
                 )*
                 Some(::core::cmp::Ordering::Equal)

--- a/rkyv_derive/src/archive/struct.rs
+++ b/rkyv_derive/src/archive/struct.rs
@@ -436,7 +436,7 @@ fn generate_partial_ord_impl(
                 &self,
                 other: &#name #ty_generics,
             ) -> Option<::core::cmp::Ordering> {
-                other.partial_cmp(self).map(|o| o.reverse())
+                other.partial_cmp(self).map(::core::cmp::Ordering::reverse)
             }
         }
     })

--- a/rkyv_derive/src/archive/struct.rs
+++ b/rkyv_derive/src/archive/struct.rs
@@ -422,7 +422,7 @@ fn generate_partial_ord_impl(
                 #(
                     match other.#members.partial_cmp(&self.#members) {
                         Some(::core::cmp::Ordering::Equal) => (),
-                        x => return x,
+                        x => return x.map(|o| o.reverse()),
                     }
                 )*
                 Some(::core::cmp::Ordering::Equal)
@@ -436,7 +436,7 @@ fn generate_partial_ord_impl(
                 &self,
                 other: &#name #ty_generics,
             ) -> Option<::core::cmp::Ordering> {
-                other.partial_cmp(self)
+                other.partial_cmp(self).map(|o| o.reverse())
             }
         }
     })

--- a/rkyv_test/src/lib.rs
+++ b/rkyv_test/src/lib.rs
@@ -182,4 +182,30 @@ mod tests {
             .iter()
             .all(|&b| b == 0));
     }
+
+    #[test]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
+    fn derive_partial_ord() {
+        use rkyv::{Archive, Deserialize, Serialize};
+
+        #[derive(
+            Archive, Deserialize, Serialize, Debug, PartialEq, PartialOrd,
+        )]
+        #[archive(compare(PartialEq, PartialOrd))]
+        #[archive_attr(derive(Debug))]
+        pub struct Foo {
+            a: i32,
+        }
+
+        let small = Foo { a: 0 };
+        let big = Foo { a: 1 };
+        assert!(small < big);
+
+        let big_bytes =
+            rkyv::to_bytes::<Error>(&big).expect("failed to serialize value");
+        let big_archived =
+            unsafe { rkyv::access_unchecked::<ArchivedFoo>(&big_bytes) };
+
+        assert!((&small as &dyn PartialOrd<ArchivedFoo>) < big_archived);
+    }
 }

--- a/rkyv_test/src/lib.rs
+++ b/rkyv_test/src/lib.rs
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
-    fn derive_partial_ord() {
+    fn derive_partial_ord_struct() {
         use rkyv::{Archive, Deserialize, Serialize};
 
         #[derive(
@@ -199,6 +199,32 @@ mod tests {
 
         let small = Foo { a: 0 };
         let big = Foo { a: 1 };
+        assert!(small < big);
+
+        let big_bytes =
+            rkyv::to_bytes::<Error>(&big).expect("failed to serialize value");
+        let big_archived =
+            unsafe { rkyv::access_unchecked::<ArchivedFoo>(&big_bytes) };
+
+        assert!((&small as &dyn PartialOrd<ArchivedFoo>) < big_archived);
+    }
+
+    #[test]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
+    fn derive_partial_ord_enum() {
+        use rkyv::{Archive, Deserialize, Serialize};
+
+        #[derive(
+            Archive, Deserialize, Serialize, Debug, PartialEq, PartialOrd,
+        )]
+        #[archive(compare(PartialEq, PartialOrd))]
+        #[archive_attr(derive(Debug))]
+        pub enum Foo {
+            A { a: i32 },
+        }
+
+        let small = Foo::A { a: 0 };
+        let big = Foo::A { a: 1 };
         assert!(small < big);
 
         let big_bytes =


### PR DESCRIPTION
Hi devs :wave: 

I noticed a correctness bug in `#[archive(compare(PartialOrd))]`. I added a failing test case, and fixed it (I think). I'd be happy to address any comments you have on the code and get a fix merged if you're taking contributions