### PR TITLE
Add PartialEq/PartialOrd impls for foreign vec types

### DIFF
--- a/rkyv/src/impls/alloc/vec.rs
+++ b/rkyv/src/impls/alloc/vec.rs
@@ -1,5 +1,3 @@
-use core::cmp;
-
 use rancor::{Fallible, ResultExt as _, Source};
 
 use crate::{
@@ -63,15 +61,11 @@ impl<T: PartialEq<U>, U> PartialEq<Vec<U>> for ArchivedVec<T> {
 }
 
 impl<T: PartialOrd<U>, U> PartialOrd<Vec<U>> for ArchivedVec<T> {
-    fn partial_cmp(&self, other: &Vec<U>) -> Option<cmp::Ordering> {
-        let min_len = self.len().min(other.len());
-        for i in 0..min_len {
-            match self[i].partial_cmp(&other[i]) {
-                Some(cmp::Ordering::Equal) => continue,
-                result => return result,
-            }
-        }
-        self.len().partial_cmp(&other.len())
+    fn partial_cmp(&self, other: &Vec<U>) -> Option<::core::cmp::Ordering> {
+        crate::impls::lexicographical_partial_ord(
+            self.as_slice(),
+            other.as_slice(),
+        )
     }
 }
 

--- a/rkyv/src/impls/arrayvec.rs
+++ b/rkyv/src/impls/arrayvec.rs
@@ -51,6 +51,24 @@ where
     }
 }
 
+impl<T, U, const CAP: usize> PartialEq<ArchivedVec<U>> for ArrayVec<T, CAP>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &ArchivedVec<U>) -> bool {
+        self.as_slice().eq(other.as_slice())
+    }
+}
+
+impl<T, U, const CAP: usize> PartialEq<ArrayVec<U, CAP>> for ArchivedVec<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &ArrayVec<U, CAP>) -> bool {
+        self.as_slice().eq(other.as_slice())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use arrayvec::ArrayVec;

--- a/rkyv/src/impls/arrayvec.rs
+++ b/rkyv/src/impls/arrayvec.rs
@@ -51,21 +51,27 @@ where
     }
 }
 
-impl<T, U, const CAP: usize> PartialEq<ArchivedVec<U>> for ArrayVec<T, CAP>
-where
-    T: PartialEq<U>,
-{
-    fn eq(&self, other: &ArchivedVec<U>) -> bool {
-        self.as_slice().eq(other.as_slice())
-    }
-}
-
 impl<T, U, const CAP: usize> PartialEq<ArrayVec<U, CAP>> for ArchivedVec<T>
 where
     T: PartialEq<U>,
 {
     fn eq(&self, other: &ArrayVec<U, CAP>) -> bool {
         self.as_slice().eq(other.as_slice())
+    }
+}
+
+impl<T, U, const CAP: usize> PartialOrd<ArrayVec<U, CAP>> for ArchivedVec<T>
+where
+    T: PartialOrd<U>,
+{
+    fn partial_cmp(
+        &self,
+        other: &ArrayVec<U, CAP>,
+    ) -> Option<::core::cmp::Ordering> {
+        crate::impls::lexicographical_partial_ord(
+            self.as_slice(),
+            other.as_slice(),
+        )
     }
 }
 

--- a/rkyv/src/impls/bytes.rs
+++ b/rkyv/src/impls/bytes.rs
@@ -43,15 +43,6 @@ where
     }
 }
 
-impl<T: Archive> PartialEq<ArchivedVec<T>> for Bytes
-where
-    bytes::Bytes: PartialEq<[T]>,
-{
-    fn eq(&self, other: &ArchivedVec<T>) -> bool {
-        self == other.as_slice()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;

--- a/rkyv/src/impls/bytes.rs
+++ b/rkyv/src/impls/bytes.rs
@@ -43,6 +43,15 @@ where
     }
 }
 
+impl<T: Archive> PartialEq<ArchivedVec<T>> for Bytes
+where
+    bytes::Bytes: PartialEq<[T]>,
+{
+    fn eq(&self, other: &ArchivedVec<T>) -> bool {
+        self == other.as_slice()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;

--- a/rkyv/src/impls/mod.rs
+++ b/rkyv/src/impls/mod.rs
@@ -36,6 +36,27 @@ mod triomphe;
 #[cfg(feature = "uuid")]
 mod uuid;
 
+use ::core::cmp::Ordering;
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn lexicographical_partial_ord<T, U>(
+    a: &[T],
+    b: &[U],
+) -> Option<Ordering>
+where
+    T: PartialOrd<U>,
+{
+    for (a, b) in a.iter().zip(b.iter()) {
+        match (*a).partial_cmp(b) {
+            Some(Ordering::Equal) => {}
+            ord => return ord,
+        }
+    }
+
+    a.len().partial_cmp(&b.len())
+}
+
 #[cfg(test)]
 mod core_tests {
     use munge::munge;

--- a/rkyv/src/impls/smallvec.rs
+++ b/rkyv/src/impls/smallvec.rs
@@ -52,6 +52,26 @@ where
     }
 }
 
+impl<A, U> PartialEq<ArchivedVec<U>> for SmallVec<A>
+where
+    A: Array,
+    A::Item: PartialEq<U>,
+{
+    fn eq(&self, other: &ArchivedVec<U>) -> bool {
+        self.as_slice().eq(other.as_slice())
+    }
+}
+
+impl<A, U> PartialEq<SmallVec<A>> for ArchivedVec<U>
+where
+    A: Array,
+    U: PartialEq<A::Item>,
+{
+    fn eq(&self, other: &SmallVec<A>) -> bool {
+        self.as_slice().eq(other.as_slice())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use smallvec::{smallvec, SmallVec};

--- a/rkyv/src/impls/smallvec.rs
+++ b/rkyv/src/impls/smallvec.rs
@@ -52,16 +52,6 @@ where
     }
 }
 
-impl<A, U> PartialEq<ArchivedVec<U>> for SmallVec<A>
-where
-    A: Array,
-    A::Item: PartialEq<U>,
-{
-    fn eq(&self, other: &ArchivedVec<U>) -> bool {
-        self.as_slice().eq(other.as_slice())
-    }
-}
-
 impl<A, U> PartialEq<SmallVec<A>> for ArchivedVec<U>
 where
     A: Array,
@@ -69,6 +59,22 @@ where
 {
     fn eq(&self, other: &SmallVec<A>) -> bool {
         self.as_slice().eq(other.as_slice())
+    }
+}
+
+impl<T, A> PartialOrd<SmallVec<A>> for ArchivedVec<T>
+where
+    A: Array,
+    T: PartialOrd<A::Item>,
+{
+    fn partial_cmp(
+        &self,
+        other: &SmallVec<A>,
+    ) -> Option<::core::cmp::Ordering> {
+        crate::impls::lexicographical_partial_ord(
+            self.as_slice(),
+            other.as_slice(),
+        )
     }
 }
 

--- a/rkyv/src/impls/smolstr.rs
+++ b/rkyv/src/impls/smolstr.rs
@@ -41,6 +41,12 @@ impl PartialEq<SmolStr> for ArchivedString {
     }
 }
 
+impl PartialOrd<SmolStr> for ArchivedString {
+    fn partial_cmp(&self, other: &SmolStr) -> Option<::core::cmp::Ordering> {
+        Some(self.as_str().cmp(other.as_str()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use smol_str::SmolStr;

--- a/rkyv/src/impls/thin_vec.rs
+++ b/rkyv/src/impls/thin_vec.rs
@@ -86,14 +86,16 @@ mod tests {
 
     #[test]
     fn test_partial_eq() {
-        #[derive(crate::Archive)]
-        #[archive(crate = crate, compare(PartialEq))]
+        use crate::Archive;
+
+        #[derive(Archive)]
+        #[rkyv(crate, compare(PartialEq, PartialOrd))]
         struct Inner {
             a: i32,
         }
 
-        #[derive(crate::Archive)]
-        #[archive(crate = crate, compare(PartialEq))]
+        #[derive(Archive)]
+        #[rkyv(crate, compare(PartialEq, PartialOrd))]
         struct Outer {
             a: ThinVec<Inner>,
         }

--- a/rkyv/src/impls/thin_vec.rs
+++ b/rkyv/src/impls/thin_vec.rs
@@ -50,6 +50,24 @@ where
     }
 }
 
+impl<T, U> PartialEq<ArchivedVec<U>> for ThinVec<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &ArchivedVec<U>) -> bool {
+        self.as_slice().eq(other.as_slice())
+    }
+}
+
+impl<T, U> PartialEq<ThinVec<U>> for ArchivedVec<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &ThinVec<U>) -> bool {
+        self.as_slice().eq(other.as_slice())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use thin_vec::ThinVec;
@@ -58,9 +76,23 @@ mod tests {
 
     #[test]
     fn roundtrip_thin_vec() {
-        roundtrip_with(
-            &ThinVec::<i32>::from_iter([10, 20, 40, 80].into_iter()),
-            |a, b| assert_eq!(**a, **b),
-        );
+        roundtrip_with(&ThinVec::<i32>::from_iter([10, 20, 40, 80]), |a, b| {
+            assert_eq!(**a, **b)
+        });
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        #[derive(crate::Archive)]
+        #[archive(crate = crate, compare(PartialEq))]
+        struct Inner {
+            a: i32,
+        }
+
+        #[derive(crate::Archive)]
+        #[archive(crate = crate, compare(PartialEq))]
+        struct Outer {
+            a: ThinVec<Inner>,
+        }
     }
 }

--- a/rkyv/src/impls/thin_vec.rs
+++ b/rkyv/src/impls/thin_vec.rs
@@ -50,21 +50,24 @@ where
     }
 }
 
-impl<T, U> PartialEq<ArchivedVec<U>> for ThinVec<T>
-where
-    T: PartialEq<U>,
-{
-    fn eq(&self, other: &ArchivedVec<U>) -> bool {
-        self.as_slice().eq(other.as_slice())
-    }
-}
-
 impl<T, U> PartialEq<ThinVec<U>> for ArchivedVec<T>
 where
     T: PartialEq<U>,
 {
     fn eq(&self, other: &ThinVec<U>) -> bool {
         self.as_slice().eq(other.as_slice())
+    }
+}
+
+impl<T, U> PartialOrd<ThinVec<U>> for ArchivedVec<T>
+where
+    T: PartialOrd<U>,
+{
+    fn partial_cmp(&self, other: &ThinVec<U>) -> Option<::core::cmp::Ordering> {
+        crate::impls::lexicographical_partial_ord(
+            self.as_slice(),
+            other.as_slice(),
+        )
     }
 }
 

--- a/rkyv/src/impls/tinyvec.rs
+++ b/rkyv/src/impls/tinyvec.rs
@@ -1,3 +1,5 @@
+use core::ops::Deref;
+
 use rancor::Fallible;
 #[cfg(all(feature = "tinyvec", feature = "alloc"))]
 use tinyvec::TinyVec;
@@ -129,6 +131,44 @@ where
             result.push(item.deserialize(deserializer)?);
         }
         Ok(result)
+    }
+}
+
+impl<A, U> PartialEq<ArchivedVec<U>> for ArrayVec<A>
+where
+    A: Array,
+    A::Item: PartialEq<U>,
+{
+    fn eq(&self, other: &ArchivedVec<U>) -> bool {
+        self.deref().eq(other.as_slice())
+    }
+}
+
+impl<T, A> PartialEq<ArrayVec<A>> for ArchivedVec<T>
+where
+    A: Array,
+    T: PartialEq<A::Item>,
+{
+    fn eq(&self, other: &ArrayVec<A>) -> bool {
+        self.as_slice().eq(other.deref())
+    }
+}
+
+impl<T, U> PartialEq<ArchivedVec<U>> for SliceVec<'_, T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &ArchivedVec<U>) -> bool {
+        self.as_slice().eq(other.as_slice())
+    }
+}
+
+impl<T, U> PartialEq<SliceVec<'_, U>> for ArchivedVec<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &SliceVec<'_, U>) -> bool {
+        self.as_slice().eq(other.as_slice())
     }
 }
 

--- a/rkyv/src/impls/tinyvec.rs
+++ b/rkyv/src/impls/tinyvec.rs
@@ -134,16 +134,6 @@ where
     }
 }
 
-impl<A, U> PartialEq<ArchivedVec<U>> for ArrayVec<A>
-where
-    A: Array,
-    A::Item: PartialEq<U>,
-{
-    fn eq(&self, other: &ArchivedVec<U>) -> bool {
-        self.deref().eq(other.as_slice())
-    }
-}
-
 impl<T, A> PartialEq<ArrayVec<A>> for ArchivedVec<T>
 where
     A: Array,
@@ -154,12 +144,19 @@ where
     }
 }
 
-impl<T, U> PartialEq<ArchivedVec<U>> for SliceVec<'_, T>
+impl<T, A> PartialOrd<ArrayVec<A>> for ArchivedVec<T>
 where
-    T: PartialEq<U>,
+    A: Array,
+    T: PartialOrd<A::Item>,
 {
-    fn eq(&self, other: &ArchivedVec<U>) -> bool {
-        self.as_slice().eq(other.as_slice())
+    fn partial_cmp(
+        &self,
+        other: &ArrayVec<A>,
+    ) -> Option<::core::cmp::Ordering> {
+        crate::impls::lexicographical_partial_ord(
+            self.as_slice(),
+            other.as_slice(),
+        )
     }
 }
 
@@ -169,6 +166,21 @@ where
 {
     fn eq(&self, other: &SliceVec<'_, U>) -> bool {
         self.as_slice().eq(other.as_slice())
+    }
+}
+
+impl<T, U> PartialOrd<SliceVec<'_, U>> for ArchivedVec<T>
+where
+    T: PartialOrd<U>,
+{
+    fn partial_cmp(
+        &self,
+        other: &SliceVec<'_, U>,
+    ) -> Option<::core::cmp::Ordering> {
+        crate::impls::lexicographical_partial_ord(
+            self.as_slice(),
+            other.as_slice(),
+        )
     }
 }
 

--- a/rkyv/src/impls/tinyvec.rs
+++ b/rkyv/src/impls/tinyvec.rs
@@ -1,5 +1,3 @@
-use core::ops::Deref;
-
 use rancor::Fallible;
 #[cfg(all(feature = "tinyvec", feature = "alloc"))]
 use tinyvec::TinyVec;
@@ -140,7 +138,7 @@ where
     T: PartialEq<A::Item>,
 {
     fn eq(&self, other: &ArrayVec<A>) -> bool {
-        self.as_slice().eq(other.deref())
+        self.as_slice().eq(other.as_slice())
     }
 }
 


### PR DESCRIPTION
Ran into a case of:
```rust
#[derive(rkyv::Archive)]
#[archive(compare(PartialEq))]
struct Inner {
    a: i32,
}

#[derive(rkyv::Archive)]
#[archive(compare(PartialEq))]
struct Outer {
    a: ThinVec<Inner>,
}
```

This PR fixes the missing `PartialEq` impls. I saw that `Vec` also implements `PartialOrd` with `ArchivedVec`, so I could also add those impls if desired, but the implementation is more complex than these so I skipped it. 