### PR TITLE
Fix type deduction of Duration in AsUnixTime

### DIFF
--- a/rkyv/src/impls/std/with.rs
+++ b/rkyv/src/impls/std/with.rs
@@ -500,7 +500,8 @@ where
         field: &ArchivedDuration,
         _: &mut D,
     ) -> Result<SystemTime, D::Error> {
-        Ok(UNIX_EPOCH + (*field).into())
+        // `checked_add` forces correct type deduction when multiple `Duration` are present.
+        Ok(UNIX_EPOCH.checked_add((*field).into()).unwrap())
     }
 }
 


### PR DESCRIPTION
If multiple `Duration` types are present it can fail to deduce the `.into()` here. 

```
= note: multiple `impl`s satisfying `SystemTime: Add<_>` found in the following crates: `std`, `time`
```

so this is a tiny change to fix that. 