### PR TITLE
Implement Positional/Writer/Sharing for references

### DIFF
--- a/rkyv/src/ser/sharing/alloc.rs
+++ b/rkyv/src/ser/sharing/alloc.rs
@@ -49,6 +49,11 @@ impl Share {
             ),
         }
     }
+
+    /// Clears the shared pointer unifier for reuse.
+    pub fn clear(&mut self) {
+        self.shared_address_to_pos.clear();
+    }
 }
 
 impl<E: Source> Sharing<E> for Share {

--- a/rkyv/src/ser/sharing/mod.rs
+++ b/rkyv/src/ser/sharing/mod.rs
@@ -24,6 +24,19 @@ pub trait Sharing<E = <Self as Fallible>::Error> {
     fn add_shared_ptr(&mut self, address: usize, pos: usize) -> Result<(), E>;
 }
 
+impl<'a, T, E> Sharing<E> for &'a mut T
+where
+    T: Sharing<E> + ?Sized,
+{
+    fn get_shared_ptr(&self, address: usize) -> Option<usize> {
+        T::get_shared_ptr(*self, address)
+    }
+
+    fn add_shared_ptr(&mut self, address: usize, pos: usize) -> Result<(), E> {
+        T::add_shared_ptr(*self, address, pos)
+    }
+}
+
 impl<T, E> Sharing<E> for Strategy<T, E>
 where
     T: Sharing<E> + ?Sized,

--- a/rkyv/src/ser/writer/mod.rs
+++ b/rkyv/src/ser/writer/mod.rs
@@ -164,10 +164,9 @@ pub trait WriterExt<E>: Writer<E> {
 
 impl<T, E> WriterExt<E> for T where T: Writer<E> + ?Sized {}
 
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 mod tests {
-    use crate::api::high::to_bytes_in;
-    use crate::util::AlignedVec;
+    use crate::{api::high::to_bytes_in, util::AlignedVec};
     use rend::{u16_le, u32_le};
 
     #[test]

--- a/rkyv/src/ser/writer/mod.rs
+++ b/rkyv/src/ser/writer/mod.rs
@@ -20,6 +20,24 @@ pub trait Positional {
     fn pos(&self) -> usize;
 }
 
+impl<'a, T> Positional for &'a T
+where
+    T: Positional + ?Sized,
+{
+    fn pos(&self) -> usize {
+        T::pos(*self)
+    }
+}
+
+impl<'a, T> Positional for &'a mut T
+where
+    T: Positional + ?Sized,
+{
+    fn pos(&self) -> usize {
+        T::pos(*self)
+    }
+}
+
 impl<T, E> Positional for Strategy<T, E>
 where
     T: Positional + ?Sized,
@@ -41,6 +59,15 @@ where
 pub trait Writer<E = <Self as Fallible>::Error>: Positional {
     /// Attempts to write the given bytes to the serializer.
     fn write(&mut self, bytes: &[u8]) -> Result<(), E>;
+}
+
+impl<'a, T, E> Writer<E> for &'a mut T
+where
+    T: Writer<E> + ?Sized,
+{
+    fn write(&mut self, bytes: &[u8]) -> Result<(), E> {
+        T::write(*self, bytes)
+    }
 }
 
 impl<T, E> Writer<E> for Strategy<T, E>
@@ -136,3 +163,31 @@ pub trait WriterExt<E>: Writer<E> {
 }
 
 impl<T, E> WriterExt<E> for T where T: Writer<E> + ?Sized {}
+
+#[cfg(test)]
+mod tests {
+    use crate::api::high::to_bytes_in;
+    use crate::util::AlignedVec;
+    use rend::{u16_le, u32_le};
+
+    #[test]
+    fn reusable_writer() {
+        let mut writer = AlignedVec::<16>::new();
+
+        _ = to_bytes_in::<_, rancor::Error>(
+            &u32_le::from_native(42),
+            &mut writer,
+        );
+        assert_eq!(&writer[..], &[42, 0, 0, 0]);
+        writer.clear(); // keeps capacity of 4
+
+        _ = to_bytes_in::<_, rancor::Error>(
+            &u16_le::from_native(1337),
+            &mut writer,
+        );
+        assert_eq!(&writer[..], &[57, 5]);
+        writer.clear();
+
+        assert_eq!(writer.capacity(), 4);
+    }
+}

--- a/rkyv/src/ser/writer/mod.rs
+++ b/rkyv/src/ser/writer/mod.rs
@@ -166,8 +166,9 @@ impl<T, E> WriterExt<E> for T where T: Writer<E> + ?Sized {}
 
 #[cfg(all(test, feature = "alloc"))]
 mod tests {
-    use crate::{api::high::to_bytes_in, util::AlignedVec};
     use rend::{u16_le, u32_le};
+
+    use crate::{api::high::to_bytes_in, util::AlignedVec};
 
     #[test]
     fn reusable_writer() {

--- a/rkyv/src/ser/writer/mod.rs
+++ b/rkyv/src/ser/writer/mod.rs
@@ -164,14 +164,15 @@ pub trait WriterExt<E>: Writer<E> {
 
 impl<T, E> WriterExt<E> for T where T: Writer<E> + ?Sized {}
 
-#[cfg(all(test, feature = "alloc"))]
+#[cfg(test)]
 mod tests {
-    use rend::{u16_le, u32_le};
-
-    use crate::{api::high::to_bytes_in, util::AlignedVec};
-
+    #[cfg(feature = "alloc")]
     #[test]
     fn reusable_writer() {
+        use rend::{u16_le, u32_le};
+
+        use crate::{api::high::to_bytes_in, util::AlignedVec};
+
         let mut writer = AlignedVec::<16>::new();
 
         _ = to_bytes_in::<_, rancor::Error>(


### PR DESCRIPTION
My RPC system uses a lot of async streams of objects that are individual/isolated but I could reuse buffers between items after the binary data is written out. Just passing in `&mut my_writer`/`&mut my_share` to a Serializer would be nice, compared to having to take apart the serializer every iteration with `into_raw_parts` to gain access to the buffers again, and having to use Options with `take` and whatnot for stuff in the loop. 

This also adds a `.clear()` method to `Share` to reset it but keep the allocated memory.