### PR TITLE
postgres-types feature implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           - bytecheck
         external:
           - ''
-          - hashbrown indexmap smallvec smol_str arrayvec tinyvec uuid bytes thin-vec triomphe
+          - hashbrown indexmap smallvec smol_str arrayvec tinyvec uuid bytes thin-vec triomphe postgres-types
 
     steps:
       - uses: actions/checkout@v4

--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -41,6 +41,9 @@ tinyvec = { version = "1.5", optional = true, default-features = false }
 triomphe = { version = "0.1", optional = true, default-features = false }
 uuid = { version = "1.3", optional = true, default-features = false }
 
+postgres-types = { version = "0.2", optional = true, default-features = false }
+postgres-protocol = { version = "0.6.7", optional = true, default-features = false }
+
 [features]
 default = ["std", "bytecheck"]
 little_endian = []
@@ -59,6 +62,7 @@ hashbrown = ["dep:hashbrown"]
 indexmap = ["dep:indexmap", "alloc"]
 triomphe = ["dep:triomphe", "alloc"]
 uuid = ["dep:uuid", "bytecheck?/uuid"]
+postgres-types = ["std", "dep:postgres-types", "bytes", "dep:postgres-protocol"]
 
 [package.metadata.docs.rs]
 features = ["bytecheck"]

--- a/rkyv/src/impls/mod.rs
+++ b/rkyv/src/impls/mod.rs
@@ -23,6 +23,8 @@ mod hashbrown;
 
 #[cfg(feature = "indexmap")]
 mod indexmap;
+#[cfg(feature = "postgres-types")]
+mod pg_types;
 #[cfg(feature = "smallvec")]
 mod smallvec;
 #[cfg(feature = "smol_str")]

--- a/rkyv/src/impls/pg_types.rs
+++ b/rkyv/src/impls/pg_types.rs
@@ -1,0 +1,162 @@
+use bytes::BytesMut;
+use postgres_types::{to_sql_checked, IsNull, ToSql, Type};
+use std::{collections::HashMap, error::Error, hash::Hasher, net::IpAddr};
+
+use crate::{
+    boxed::ArchivedBox, collections::swiss_table::ArchivedHashMap,
+    net::ArchivedIpAddr, niche::option_box::ArchivedOptionBox,
+    option::ArchivedOption, rc::ArchivedRc, string::ArchivedString,
+    vec::ArchivedVec,
+};
+
+macro_rules! fwd_accepts {
+    ($ty:ty) => {
+        #[inline]
+        fn accepts(ty: &Type) -> bool {
+            <$ty as ToSql>::accepts(ty)
+        }
+    };
+}
+
+impl ToSql for ArchivedString {
+    #[inline]
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        self.as_str().to_sql(ty, out)
+    }
+
+    fwd_accepts!(&str);
+    to_sql_checked!();
+}
+
+impl<T> ToSql for ArchivedVec<T>
+where
+    T: ToSql,
+{
+    #[inline]
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        self.as_slice().to_sql(ty, out)
+    }
+
+    fwd_accepts!(&[T]);
+    to_sql_checked!();
+}
+
+impl<T> ToSql for ArchivedOption<T>
+where
+    T: ToSql,
+{
+    #[inline]
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        match self {
+            ArchivedOption::Some(value) => value.to_sql(ty, out),
+            ArchivedOption::None => Ok(IsNull::Yes),
+        }
+    }
+
+    fwd_accepts!(Option<T>);
+    to_sql_checked!();
+}
+
+impl<T> ToSql for ArchivedBox<T>
+where
+    T: ToSql,
+{
+    #[inline]
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        self.as_ref().to_sql(ty, out)
+    }
+
+    fwd_accepts!(T);
+    to_sql_checked!();
+}
+
+impl<T> ToSql for ArchivedOptionBox<T>
+where
+    T: ToSql,
+{
+    #[inline]
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        match self.as_ref() {
+            Some(value) => value.to_sql(ty, out),
+            None => Ok(IsNull::Yes),
+        }
+    }
+
+    fwd_accepts!(Option<T>);
+    to_sql_checked!();
+}
+
+impl<T, F> ToSql for ArchivedRc<T, F>
+where
+    T: ToSql,
+{
+    #[inline]
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        self.as_ref().to_sql(ty, out)
+    }
+
+    fwd_accepts!(T);
+    to_sql_checked!();
+}
+
+impl ToSql for ArchivedIpAddr {
+    #[inline]
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        self.as_ipaddr().to_sql(ty, out)
+    }
+
+    fwd_accepts!(IpAddr);
+    to_sql_checked!();
+}
+
+impl<H> ToSql
+    for ArchivedHashMap<ArchivedString, ArchivedOption<ArchivedString>, H>
+where
+    H: Hasher,
+{
+    #[inline]
+    fn to_sql(
+        &self,
+        _ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        postgres_protocol::types::hstore_to_sql(
+            self.iter()
+                .map(|(k, v)| (k.as_ref(), v.as_ref().map(|v| v.as_ref()))),
+            out,
+        )?;
+
+        Ok(IsNull::No)
+    }
+
+    fwd_accepts!(HashMap<String, Option<String>>);
+    to_sql_checked!();
+}

--- a/rkyv/src/impls/pg_types.rs
+++ b/rkyv/src/impls/pg_types.rs
@@ -1,6 +1,7 @@
+use std::{collections::HashMap, error::Error, hash::Hasher, net::IpAddr};
+
 use bytes::BytesMut;
 use postgres_types::{to_sql_checked, IsNull, ToSql, Type};
-use std::{collections::HashMap, error::Error, hash::Hasher, net::IpAddr};
 
 use crate::{
     boxed::ArchivedBox, collections::swiss_table::ArchivedHashMap,

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -150,6 +150,8 @@
 //! - [`tinyvec`](https://docs.rs/tinyvec)
 //! - [`triomphe`](https://docs.rs/triomphe)
 //! - [`uuid`](https://docs.rs/uuid)
+//! - [`postgres-types`](https://docs.rs/postgres-types) (`ToSql` implentations
+//!   on rkyv types)
 //!
 //! ## Compatibility
 //!


### PR DESCRIPTION
As discussed on Discord. The `postgres-types` crate doesn't keep up that well with dependencies or adding new ones, sometimes, so it's probably just easier to add support here. The implementations are very simple at least.

Should I also open a PR on `rend` to add support for primitives? Personally I don't use archived primitives often in my SQL. 