### PR TITLE
Forward alloc feature to rancor

### DIFF
--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -50,7 +50,7 @@ unaligned = []
 pointer_width_16 = []
 pointer_width_32 = []
 pointer_width_64 = []
-alloc = ["dep:hashbrown", "tinyvec?/alloc"]
+alloc = ["dep:hashbrown", "tinyvec?/alloc", "rancor/alloc"]
 std = ["alloc", "bytecheck?/std", "bytes?/std", "indexmap?/std", "ptr_meta/std", "uuid?/std"]
 bytecheck = ["dep:bytecheck", "bytecheck/derive", "rend/bytecheck", "rkyv_derive/bytecheck"]
 


### PR DESCRIPTION
This enables the type `rkyv::rancor::BoxedError` when the `alloc` feature is enabled for `rkyv`.