### PR TITLE
Implement `*With` traits via derive macros

### DIFF
--- a/rkyv/tests/derive.rs
+++ b/rkyv/tests/derive.rs
@@ -194,7 +194,7 @@ fn named_struct_private() {
                 self.inner
             }
 
-            pub fn as_inner(&self) -> &[u8; 4] {
+            pub fn inner_ref(&self) -> &[u8; 4] {
                 &self.inner
             }
         }
@@ -218,7 +218,7 @@ fn named_struct_private() {
     #[rkyv(remote = remote::Remote)]
     #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
     struct ExampleThroughRef {
-        #[with(remote(getter = remote::Remote::as_inner))]
+        #[with(remote(getter = remote::Remote::inner_ref))]
         inner: [u8; 4],
     }
 
@@ -248,7 +248,7 @@ fn unnamed_struct_private() {
                 self.0
             }
 
-            pub fn as_inner(&self) -> &[u8; 4] {
+            pub fn inner_ref(&self) -> &[u8; 4] {
                 &self.0
             }
         }
@@ -272,7 +272,7 @@ fn unnamed_struct_private() {
     #[rkyv(remote = remote::Remote)]
     #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
     struct ExampleThroughRef(
-        #[with(remote(getter = remote::Remote::as_inner))] [u8; 4],
+        #[with(remote(getter = remote::Remote::inner_ref))] [u8; 4],
     );
 
     impl From<ExampleThroughRef> for remote::Remote {

--- a/rkyv/tests/derive.rs
+++ b/rkyv/tests/derive.rs
@@ -1,0 +1,364 @@
+use std::{fmt::Debug, marker::PhantomData, path::PathBuf};
+
+use rancor::{Fallible, Panic, ResultExt, Strategy};
+use rkyv::{
+    api::high::HighSerializer, ser::allocator::ArenaHandle, util::AlignedVec, with::{ArchiveWith, AsString, DeserializeWith, Map, SerializeWith}, Archive, Archived, Deserialize, Place, Resolver, Serialize
+};
+
+#[cfg(feature = "bytecheck")]
+pub trait CheckedArchived: for<'a> rkyv::bytecheck::CheckBytes<rkyv::api::high::HighValidator<'a, Panic>> {}
+
+#[cfg(feature = "bytecheck")]
+impl<Archived: for<'a> rkyv::bytecheck::CheckBytes<rkyv::api::high::HighValidator<'a, Panic>>> CheckedArchived for Archived {}
+
+#[cfg(not(feature = "bytecheck"))]
+pub trait CheckedArchived {}
+
+#[cfg(not(feature = "bytecheck"))]
+impl<Archived> CheckedArchived for Archived {}
+
+type Serializer<'a> = HighSerializer<'a, AlignedVec, ArenaHandle<'a>, Panic>;
+
+fn serialize<F, T>(remote: &T) -> AlignedVec
+where
+    F: for<'a> SerializeWith<T, Serializer<'a>>,
+{
+    struct Wrap<'a, F, T>(&'a T, PhantomData<F>);
+
+    impl<F, T> Archive for Wrap<'_, F, T>
+    where
+        F: ArchiveWith<T>,
+    {
+        type Archived = <F as ArchiveWith<T>>::Archived;
+        type Resolver = <F as ArchiveWith<T>>::Resolver;
+
+        fn resolve(
+            &self,
+            resolver: Self::Resolver,
+            out: Place<Self::Archived>,
+        ) {
+            F::resolve_with(self.0, resolver, out)
+        }
+    }
+
+    impl<'a, F, T> Serialize<Serializer<'a>> for Wrap<'_, F, T>
+    where
+        F: SerializeWith<T, Serializer<'a>>,
+    {
+        fn serialize(
+            &self,
+            serializer: &mut Serializer<'a>,
+        ) -> Result<Self::Resolver, Panic> {
+            F::serialize_with(self.0, serializer)
+        }
+    }
+
+    let wrap = Wrap(remote, PhantomData::<F>);
+
+    rkyv::api::high::to_bytes::<Panic>(&wrap).always_ok()
+}
+
+fn access<F, T>(
+    bytes: &[u8],
+) -> &<F as ArchiveWith<T>>::Archived
+where
+    F: ArchiveWith<T, Archived: CheckedArchived>,
+{
+    #[cfg(feature = "bytecheck")]
+    {
+        rkyv::access::<<F as ArchiveWith<T>>::Archived, Panic>(bytes).always_ok()
+    }
+
+    #[cfg(not(feature = "bytecheck"))]
+    unsafe {
+        rkyv::access_unchecked::<<F as ArchiveWith<T>>::Archived>(bytes)
+    }
+}
+
+fn roundtrip<F, T>(remote: &T)
+where
+    F: ArchiveWith<T, Archived: CheckedArchived>
+        + for<'a> SerializeWith<T, Serializer<'a>>
+        + DeserializeWith<
+            <F as ArchiveWith<T>>::Archived,
+            T,
+            Strategy<(), Panic>,
+        >,
+    T: Debug + PartialEq,
+{
+    let bytes = serialize::<F, T>(remote);
+    let archived = access::<F, T>(&bytes);
+    let deserialized: T =
+        F::deserialize_with(archived, Strategy::wrap(&mut ())).always_ok();
+
+    assert_eq!(remote, &deserialized);
+}
+
+struct Identity;
+
+impl<T: Archive> ArchiveWith<T> for Identity {
+    type Archived = Archived<T>;
+    type Resolver = Resolver<T>;
+
+    fn resolve_with(
+        this: &T,
+        resolver: Self::Resolver,
+        out: Place<Self::Archived>,
+    ) {
+        this.resolve(resolver, out);
+    }
+}
+
+impl<S: Fallible + ?Sized, T: Serialize<S>> SerializeWith<T, S> for Identity {
+    fn serialize_with(
+        this: &T,
+        serializer: &mut S,
+    ) -> Result<Self::Resolver, <S as Fallible>::Error> {
+        this.serialize(serializer)
+    }
+}
+
+impl<D, T> DeserializeWith<Archived<T>, T, D> for Identity
+where
+    D: Fallible + ?Sized,
+    T: Archive,
+    Archived<T>: Deserialize<T, D>
+{
+    fn deserialize_with(archived: &Archived<T>, deserializer: &mut D)
+        -> Result<T, <D as Fallible>::Error> {
+            archived.deserialize(deserializer)
+    }
+}
+
+#[test]
+fn named_struct() {
+    #[derive(Debug, PartialEq)]
+    struct Remote<A> {
+        a: u8,
+        b: Vec<A>,
+        c: Option<PathBuf>,
+        d: Option<PathBuf>,
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = Remote::<A>)]
+    #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
+    struct Example<A> {
+        a: u8,
+        #[with(Identity)]
+        b: Vec<A>,
+        #[with(remote(Option<PathBuf>, with = Map<AsString>))]
+        c: Option<String>,
+        #[with(Map<Identity>, remote(Option<PathBuf>, with = Map<AsString>))]
+        d: Option<String>,
+    }
+
+    let remote = Remote {
+        a: 0,
+        b: Vec::new(),
+        c: Some("c".into()),
+        d: Some("d".into())
+    };
+
+    roundtrip::<Example<i32>, _>(&remote);
+}
+
+#[test]
+fn unnamed_struct() {
+    #[derive(Debug, PartialEq)]
+    struct Remote<A>(u8, Vec<A>, Option<PathBuf>, Option<PathBuf>);
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = Remote::<A>)]
+    #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
+    struct Example<A>(
+        u8,
+        #[with(Identity)] Vec<A>,
+        #[with(remote(Option<PathBuf>, with = Map<AsString>))] Option<String>,
+        #[with(Map<Identity>, remote(Option<PathBuf>, with = Map<AsString>))] Option<String>,
+    );
+
+    let remote = Remote(0, Vec::new(), Some("2".into()), Some("3".into()));
+    roundtrip::<Example<i32>, _>(&remote);
+}
+
+#[test]
+fn unit_struct() {
+    #[derive(Debug, PartialEq)]
+    struct Remote;
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = Remote)]
+    #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
+    struct Example;
+
+    let remote = Remote;
+    roundtrip::<Example, _>(&remote);
+}
+
+#[test]
+fn full_enum() {
+    #[derive(Debug, PartialEq)]
+    enum Remote<A> {
+        A,
+        B(u8),
+        C {
+            a: Vec<A>,
+            b: Option<PathBuf>,
+            c: Option<PathBuf>,
+        },
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = Remote::<A>)]
+    #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
+    enum Example<A> {
+        A,
+        B(u8),
+        C {
+            #[with(Identity)]
+            a: Vec<A>,
+            #[with(remote(Option<PathBuf>, with = Map<AsString>))]
+            b: Option<String>,
+            #[with(Map<Identity>, remote(Option<PathBuf>, with = Map<AsString>))]
+            c: Option<String>,
+        },
+    }
+
+    for remote in [
+        Remote::A,
+        Remote::B(0),
+        Remote::C {
+            a: Vec::new(),
+            b: Some("b".into()),
+            c: Some("c".into()),
+        },
+    ] {
+        roundtrip::<Example<i32>, _>(&remote);
+    }
+}
+
+#[test]
+fn named_struct_private() {
+    mod remote {
+        #[derive(Copy, Clone, Default)]
+        pub struct Remote {
+            inner: [u8; 4],
+        }
+
+        impl Remote {
+            pub fn new(inner: [u8; 4]) -> Self {
+                Self { inner }
+            }
+
+            pub fn into_inner(self) -> [u8; 4] {
+                self.inner
+            }
+
+            pub fn to_inner(&self) -> [u8; 4] {
+                self.inner
+            }
+
+            pub fn as_inner(&self) -> &[u8; 4] {
+                &self.inner
+            }
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = remote::Remove)]
+    #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
+    struct ExampleByVal {
+        #[with(remote(getter = remote::Remote::into_inner))]
+        inner: [u8; 4],
+    }
+
+    impl From<ExampleByVal> for remote::Remote {
+        fn from(value: ExampleByVal) -> Self {
+            remote::Remote::new(value.inner)
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = remote::Remote)]
+    #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
+    struct ExampleByRef {
+        #[with(remote(getter = remote::Remote::to_inner))]
+        inner: [u8; 4],
+    }
+
+    impl From<ExampleByRef> for remote::Remote {
+        fn from(value: ExampleByRef) -> Self {
+            remote::Remote::new(value.inner)
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = remote::Remote)]
+    #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
+    struct ExampleThroughRef {
+        #[with(remote(getter = remote::Remote::as_inner))]
+        inner: [u8; 4],
+    }
+
+    impl From<ExampleThroughRef> for remote::Remote {
+        fn from(value: ExampleThroughRef) -> Self {
+            remote::Remote::new(value.inner)
+        }
+    }
+
+    let remote = remote::Remote::default();
+    roundtrip::<ExampleByRef, _>(&remote);
+    roundtrip::<ExampleByRef, _>(&remote);
+    roundtrip::<ExampleThroughRef, _>(&remote);
+}
+
+#[test]
+fn unnamed_struct_private() {
+    mod remote {
+        #[derive(Copy, Clone, Default)]
+        pub struct Remote([u8; 4]);
+
+        impl Remote {
+            pub fn new(inner: [u8; 4]) -> Self {
+                Self(inner)
+            }
+
+            pub fn into_inner(self) -> [u8; 4] {
+                self.0
+            }
+
+            pub fn as_inner(&self) -> [u8; 4] {
+                self.0
+            }
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = remote::Remote)]
+    #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
+    struct ExampleByRef(#[with(remote(getter = remote::Remote::as_inner))] [u8; 4]);
+
+    impl From<ExampleByRef> for remote::Remote {
+        fn from(value: ExampleByRef) -> Self {
+            remote::Remote::new(value.0)
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = remote::Remote)]
+    #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
+    struct ExampleByVal(
+        #[with(remote(getter = remote::Remote::into_inner))] [u8; 4],
+    );
+
+    impl From<ExampleByVal> for remote::Remote {
+        fn from(value: ExampleByVal) -> Self {
+            remote::Remote::new(value.0)
+        }
+    }
+
+    let remote = remote::Remote::default();
+    roundtrip::<ExampleByRef, _>(&remote);
+    roundtrip::<ExampleByVal, _>(&remote);
+}

--- a/rkyv/tests/derive.rs
+++ b/rkyv/tests/derive.rs
@@ -324,7 +324,7 @@ fn named_struct_private() {
                 Self { inner }
             }
 
-            pub fn to_inner(&self) -> [u8; 4] {
+            pub fn inner(&self) -> [u8; 4] {
                 self.inner
             }
 
@@ -338,7 +338,7 @@ fn named_struct_private() {
     #[rkyv(remote = remote::Remote)]
     #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
     struct ExampleByRef {
-        #[with(remote(getter = remote::Remote::to_inner))]
+        #[with(remote(getter = remote::Remote::inner))]
         inner: [u8; 4],
     }
 
@@ -378,7 +378,7 @@ fn unnamed_struct_private() {
                 Self(inner)
             }
 
-            pub fn to_inner(&self) -> [u8; 4] {
+            pub fn inner(&self) -> [u8; 4] {
                 self.0
             }
 
@@ -391,7 +391,7 @@ fn unnamed_struct_private() {
     #[derive(Archive, Serialize, Deserialize)]
     #[rkyv(remote = remote::Remote)]
     #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
-    struct ExampleByRef(#[with(remote(getter = remote::Remote::to_inner))] [u8; 4]);
+    struct ExampleByRef(#[with(remote(getter = remote::Remote::inner))] [u8; 4]);
 
     impl From<ExampleByRef> for remote::Remote {
         fn from(value: ExampleByRef) -> Self {

--- a/rkyv/tests/derive.rs
+++ b/rkyv/tests/derive.rs
@@ -10,10 +10,19 @@ use rkyv::{
 };
 
 #[cfg(feature = "bytecheck")]
-pub trait CheckedArchived: for<'a> rkyv::bytecheck::CheckBytes<rkyv::api::high::HighValidator<'a, Panic>> {}
+pub trait CheckedArchived: 
+    for<'a> rkyv::bytecheck::CheckBytes<
+        rkyv::api::high::HighValidator<'a, Panic>
+    >
+{}
 
 #[cfg(feature = "bytecheck")]
-impl<Archived: for<'a> rkyv::bytecheck::CheckBytes<rkyv::api::high::HighValidator<'a, Panic>>> CheckedArchived for Archived {}
+impl<Archived:
+    for<'a> rkyv::bytecheck::CheckBytes<
+        rkyv::api::high::HighValidator<'a, Panic>
+    >
+>
+CheckedArchived for Archived {}
 
 #[cfg(not(feature = "bytecheck"))]
 pub trait CheckedArchived {}
@@ -223,7 +232,11 @@ fn unnamed_struct() {
         u8,
         #[with(Identity, remote(with = Identity2))] Vec<A>,
         #[with(remote(Option<PathBuf>, with = Map<AsString>))] Option<String>,
-        #[with(Map<Identity>, remote(Option<PathBuf>, with = Map<AsString>))] Option<String>,
+        #[with(
+            Map<Identity>,
+            remote(Option<PathBuf>, with = Map<AsString>)
+        )]
+        Option<String>,
     );
 
     impl<A> From<Example<A>> for Remote<A> {
@@ -279,7 +292,10 @@ fn full_enum() {
             a: Vec<A>,
             #[with(remote(Option<PathBuf>, with = Map<AsString>))]
             b: Option<String>,
-            #[with(Map<Identity>, remote(Option<PathBuf>, with = Map<AsString>))]
+            #[with(
+                Map<Identity>,
+                remote(Option<PathBuf>, with = Map<AsString>)
+            )]
             c: Option<String>,
         },
     }
@@ -391,7 +407,10 @@ fn unnamed_struct_private() {
     #[derive(Archive, Serialize, Deserialize)]
     #[rkyv(remote = remote::Remote)]
     #[cfg_attr(feature = "bytecheck", rkyv(check_bytes))]
-    struct ExampleByRef(#[with(remote(getter = remote::Remote::inner))] [u8; 4]);
+    struct ExampleByRef(
+        #[with(remote(getter = remote::Remote::inner))]
+        [u8; 4]
+    );
 
     impl From<ExampleByRef> for remote::Remote {
         fn from(value: ExampleByRef) -> Self {

--- a/rkyv_derive/src/archive/enum.rs
+++ b/rkyv_derive/src/archive/enum.rs
@@ -11,7 +11,7 @@ use crate::{
         resolver_variant_doc, variant_doc,
     },
     attributes::Attributes,
-    util::{archived, is_not_omitted, resolve, resolve_remote, resolver, strip_raw},
+    util::{archived, is_not_omitted, resolve, resolve_remote, resolver, strip_generics_from_path, strip_raw},
 };
 
 pub fn impl_enum(
@@ -131,7 +131,7 @@ pub fn impl_enum(
             printing,
             generics,
             data,
-            remote,
+            &strip_generics_from_path(remote.clone()),
             resolve_remote
         )?;
 

--- a/rkyv_derive/src/archive/enum.rs
+++ b/rkyv_derive/src/archive/enum.rs
@@ -361,7 +361,7 @@ fn generate_resolve_arms(
                 } => {
                     match __this {
                         #name::#variant_name {
-                            #(#members: #self_bindings,)*
+                            #(#members: #self_bindings,)* ..
                         } => {
                             let out = unsafe {
                                 out.cast_unchecked::<
@@ -405,7 +405,7 @@ fn generate_resolve_arms(
             Fields::Unnamed(_) => result.extend(quote! {
                 #resolver_name::#variant_name( #(#resolver_bindings,)* ) => {
                     match __this {
-                        #name::#variant_name(#(#self_bindings,)*) => {
+                        #name::#variant_name(#(#self_bindings,)* ..) => {
                             let out = unsafe {
                                 out.cast_unchecked::<
                                     #archived_variant_name #ty_generics

--- a/rkyv_derive/src/archive/enum.rs
+++ b/rkyv_derive/src/archive/enum.rs
@@ -11,7 +11,10 @@ use crate::{
         resolver_variant_doc, variant_doc,
     },
     attributes::Attributes,
-    util::{archived, is_not_omitted, resolve, resolve_remote, resolver, strip_generics_from_path, strip_raw},
+    util::{
+        archived, is_not_omitted, resolve, resolve_remote, resolver,
+        strip_generics_from_path, strip_raw,
+    },
 };
 
 pub fn impl_enum(
@@ -70,7 +73,7 @@ pub fn impl_enum(
         generics,
         data,
         &parse_quote!(#name),
-        resolve
+        resolve,
     )?;
 
     if let Some(ref compares) = attributes.compares {
@@ -132,21 +135,22 @@ pub fn impl_enum(
             generics,
             data,
             &strip_generics_from_path(remote.clone()),
-            resolve_remote
+            resolve_remote,
         )?;
 
         result.extend(quote! {
             const _: () = {
                 #private
 
-                impl #impl_generics #rkyv_path::with::ArchiveWith<#remote> for #name #ty_generics
+                impl #impl_generics #rkyv_path::with::ArchiveWith<#remote>
+                    for #name #ty_generics
                 #where_clause
                 {
                     type Archived = #archived_type;
                     type Resolver = #resolver_name #ty_generics;
 
-                    // Some resolvers will be (), this allow is to prevent clippy
-                    // from complaining
+                    // Some resolvers will be (), this allow is to prevent
+                    // clippy from complaining
                     #[allow(clippy::unit_arg)]
                     fn resolve_with(
                         field: &#remote,

--- a/rkyv_derive/src/archive/mod.rs
+++ b/rkyv_derive/src/archive/mod.rs
@@ -11,7 +11,10 @@ use syn::{
 use crate::{
     archive::printing::Printing,
     attributes::Attributes,
-    util::{archive_bound, archived, is_not_omitted, iter_fields},
+    util::{
+        archive_bound, archive_remote_bound, archived, is_not_omitted,
+        iter_fields,
+    },
 };
 
 pub fn derive(input: &mut DeriveInput) -> Result<TokenStream, Error> {
@@ -75,6 +78,12 @@ fn derive_archive_impl(
         where_clause
             .predicates
             .push(archive_bound(&printing.rkyv_path, field)?);
+
+        if let Some(remote_clause) =
+            archive_remote_bound(&printing.rkyv_path, field)?
+        {
+            where_clause.predicates.push(remote_clause);
+        }
     }
 
     let mut result = match &input.data {

--- a/rkyv_derive/src/archive/struct.rs
+++ b/rkyv_derive/src/archive/struct.rs
@@ -9,7 +9,10 @@ use crate::{
         archive_field_metas, archived_doc, printing::Printing, resolver_doc,
     },
     attributes::Attributes,
-    util::{archived, is_not_omitted, remote_field_access, resolve, resolve_remote, resolver},
+    util::{
+        archived, is_not_omitted, remote_field_access, resolve, resolve_remote,
+        resolver,
+    },
 };
 
 pub fn impl_struct(
@@ -104,7 +107,9 @@ pub fn impl_struct(
         }
 
         result.extend(quote! {
-            impl #impl_generics #rkyv_path::with::ArchiveWith<#remote> for #name #ty_generics
+            impl #impl_generics
+                #rkyv_path::with::ArchiveWith<#remote>
+                for #name #ty_generics
             #where_clause
             {
                 type Archived = #archived_type;

--- a/rkyv_derive/src/archive/struct.rs
+++ b/rkyv_derive/src/archive/struct.rs
@@ -9,7 +9,7 @@ use crate::{
         archive_field_metas, archived_doc, printing::Printing, resolver_doc,
     },
     attributes::Attributes,
-    util::{archived, is_not_omitted, resolve, resolve_remote, resolver},
+    util::{archived, is_not_omitted, remote_field_access, resolve, resolve_remote, resolver},
 };
 
 pub fn impl_struct(
@@ -91,6 +91,7 @@ pub fn impl_struct(
         let mut resolve_with_statements = TokenStream::new();
         for (field, member) in fields.iter().zip(fields.members()) {
             let resolves = resolve_remote(rkyv_path, field)?;
+            let field_access = remote_field_access(field, &member)?;
             resolve_with_statements.extend(quote! {
                 let field_ptr = unsafe {
                     ::core::ptr::addr_of_mut!((*out.ptr()).#member)
@@ -98,7 +99,7 @@ pub fn impl_struct(
                 let field_out = unsafe {
                     #rkyv_path::Place::from_field_unchecked(out, field_ptr)
                 };
-                #resolves(&field.#member, resolver.#member, field_out);
+                #resolves(#field_access, resolver.#member, field_out);
             });
         }
 

--- a/rkyv_derive/src/archive/struct.rs
+++ b/rkyv_derive/src/archive/struct.rs
@@ -87,6 +87,29 @@ pub fn impl_struct(
         }
     }
 
+    if let Some(ref remote) = attributes.remote {
+        result.extend(quote! {
+            impl #impl_generics #rkyv_path::with::ArchiveWith<#remote> for #name #ty_generics
+            #where_clause
+            {
+                type Archived = #archived_type;
+                type Resolver = #resolver_name #ty_generics;
+
+                // Some resolvers will be (), this allow is to prevent clippy
+                // from complaining.
+                #[allow(clippy::unit_arg)]
+                fn resolve_with(
+                    field: &#remote,
+                    resolver: Self::Resolver,
+                    out: #rkyv_path::Place<Self::Archived>,
+                ) {
+                    // #resolve_statements
+                    todo!()
+                }
+            }
+        });
+    }
+
     Ok(result)
 }
 

--- a/rkyv_derive/src/deserialize.rs
+++ b/rkyv_derive/src/deserialize.rs
@@ -7,7 +7,10 @@ use syn::{
 
 use crate::{
     attributes::Attributes,
-    util::{archive_bound, archive_remote_bound, deserialize, deserialize_bound, is_not_omitted},
+    util::{
+        archive_bound, archive_remote_bound, deserialize, deserialize_bound,
+        is_not_omitted,
+    },
 };
 
 pub fn derive(input: DeriveInput) -> Result<TokenStream, Error> {
@@ -117,7 +120,9 @@ fn derive_deserialize_impl(
                         #deserialize_where
                         {
                             fn deserialize_with(
-                                field: &#rkyv_path::Archived<#name #ty_generics>,
+                                field: &#rkyv_path::Archived<
+                                    #name #ty_generics
+                                >,
                                 deserializer: &mut __D,
                             ) -> ::core::result::Result<
                                 #remote,
@@ -200,13 +205,18 @@ fn derive_deserialize_impl(
                             #deserialize_where
                             {
                                 fn deserialize_with(
-                                    field: &#rkyv_path::Archived<#name #ty_generics>,
+                                    field: &#rkyv_path::Archived<
+                                        #name #ty_generics
+                                    >,
                                     deserializer: &mut __D,
                                 ) -> ::core::result::Result<
                                     #remote,
-                                    <__D as #rkyv_path::rancor::Fallible>::Error,
+                                    <
+                                        __D as #rkyv_path::rancor::Fallible
+                                    >::Error,
                                 > {
-                                    field.deserialize(deserializer).map(From::from)
+                                    field.deserialize(deserializer)
+                                        .map(From::from)
                                 }
                             }
                         }
@@ -249,11 +259,15 @@ fn derive_deserialize_impl(
                             #where_clause
                             {
                                 fn deserialize_with(
-                                    field: &#rkyv_path::Archived<#name #ty_generics>,
+                                    field: &#rkyv_path::Archived<
+                                        #name #ty_generics
+                                    >,
                                     _: &mut __D,
                                 ) -> ::core::result::Result<
                                     #remote,
-                                    <__D as #rkyv_path::rancor::Fallible>::Error,
+                                    <
+                                        __D as #rkyv_path::rancor::Fallible
+                                    >::Error,
                                 > {
                                     Ok(#remote)
                                 }
@@ -283,7 +297,9 @@ fn derive_deserialize_impl(
                             if let Some(remote_clause) =
                                 archive_remote_bound(&rkyv_path, field)?
                             {
-                                deserialize_where.predicates.push(remote_clause);
+                                deserialize_where
+                                    .predicates
+                                    .push(remote_clause);
                             }
                         }
                     }
@@ -301,7 +317,9 @@ fn derive_deserialize_impl(
                             if let Some(remote_clause) =
                                 archive_remote_bound(&rkyv_path, field)?
                             {
-                                deserialize_where.predicates.push(remote_clause);
+                                deserialize_where
+                                    .predicates
+                                    .push(remote_clause);
                             }
                         }
                     }
@@ -414,7 +432,9 @@ fn derive_deserialize_impl(
                         #deserialize_where
                         {
                             fn deserialize_with(
-                                field: &#rkyv_path::Archived<#name #ty_generics>,
+                                field: &#rkyv_path::Archived<
+                                    #name #ty_generics
+                                >,
                                 deserializer: &mut __D,
                             ) -> ::core::result::Result<
                                 #remote,

--- a/rkyv_derive/src/deserialize.rs
+++ b/rkyv_derive/src/deserialize.rs
@@ -405,7 +405,11 @@ fn derive_deserialize_impl(
                     quote! {
                         #[automatically_derived]
                         impl #impl_generics
-                            #rkyv_path::with::DeserializeWith<#rkyv_path::Archived<#name #ty_generics>, #remote, __D>
+                            #rkyv_path::with::DeserializeWith<
+                                #rkyv_path::Archived<#name #ty_generics>,
+                                #remote,
+                                __D,
+                            >
                             for #name #ty_generics
                         #deserialize_where
                         {

--- a/rkyv_derive/src/deserialize.rs
+++ b/rkyv_derive/src/deserialize.rs
@@ -7,7 +7,7 @@ use syn::{
 
 use crate::{
     attributes::Attributes,
-    util::{archive_bound, deserialize, deserialize_bound, is_not_omitted},
+    util::{archive_bound, archive_remote_bound, deserialize, deserialize_bound, is_not_omitted},
 };
 
 pub fn derive(input: DeriveInput) -> Result<TokenStream, Error> {
@@ -62,6 +62,12 @@ fn derive_deserialize_impl(
                     deserialize_where
                         .predicates
                         .push(deserialize_bound(&rkyv_path, field)?);
+
+                    if let Some(remote_clause) =
+                        archive_remote_bound(&rkyv_path, field)?
+                    {
+                        deserialize_where.predicates.push(remote_clause);
+                    }
                 }
 
                 let deserialize_fields = fields
@@ -136,6 +142,12 @@ fn derive_deserialize_impl(
                     deserialize_where
                         .predicates
                         .push(deserialize_bound(&rkyv_path, field)?);
+
+                    if let Some(remote_clause) =
+                        archive_remote_bound(&rkyv_path, field)?
+                    {
+                        deserialize_where.predicates.push(remote_clause);
+                    }
                 }
 
                 let deserialize_fields = fields
@@ -267,6 +279,12 @@ fn derive_deserialize_impl(
                             deserialize_where
                                 .predicates
                                 .push(deserialize_bound(&rkyv_path, field)?);
+
+                            if let Some(remote_clause) =
+                                archive_remote_bound(&rkyv_path, field)?
+                            {
+                                deserialize_where.predicates.push(remote_clause);
+                            }
                         }
                     }
                     Fields::Unnamed(ref fields) => {
@@ -279,6 +297,12 @@ fn derive_deserialize_impl(
                             deserialize_where
                                 .predicates
                                 .push(deserialize_bound(&rkyv_path, field)?);
+
+                            if let Some(remote_clause) =
+                                archive_remote_bound(&rkyv_path, field)?
+                            {
+                                deserialize_where.predicates.push(remote_clause);
+                            }
                         }
                     }
                     Fields::Unit => (),

--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -229,8 +229,7 @@ fn derive_serialize_impl(
                                 Self::Resolver,
                                 <__S as #rkyv_path::rancor::Fallible>::Error,
                             > {
-                                // Ok(#resolver)
-                                todo!()
+                                Ok(#resolver)
                             }
                         }
                     }

--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -7,7 +7,7 @@ use syn::{
 
 use crate::{
     attributes::Attributes,
-    util::{is_not_omitted, serialize, serialize_bound, strip_raw},
+    util::{is_not_omitted, serialize, serialize_bound, serialize_remote_bound, strip_raw},
 };
 
 pub fn derive(input: DeriveInput) -> Result<TokenStream, Error> {
@@ -64,6 +64,12 @@ fn derive_serialize_impl(
                     serialize_where
                         .predicates
                         .push(serialize_bound(&rkyv_path, field)?);
+
+                    if let Some(remote_clause) =
+                        serialize_remote_bound(&rkyv_path, field)?
+                    {
+                        serialize_where.predicates.push(remote_clause);
+                    }
                 }
 
                 let resolver_values = fields.named.iter().map(|field| {
@@ -124,6 +130,12 @@ fn derive_serialize_impl(
                     serialize_where
                         .predicates
                         .push(serialize_bound(&rkyv_path, field)?);
+
+                    if let Some(remote_clause) =
+                        serialize_remote_bound(&rkyv_path, field)?
+                    {
+                        serialize_where.predicates.push(remote_clause);
+                    }
                 }
 
                 let resolver_values = fields
@@ -239,6 +251,12 @@ fn derive_serialize_impl(
                             serialize_where
                                 .predicates
                                 .push(serialize_bound(&rkyv_path, field)?);
+
+                            if let Some(remote_clause) =
+                                serialize_remote_bound(&rkyv_path, field)?
+                            {
+                                serialize_where.predicates.push(remote_clause);
+                            }
                         }
                     }
                     Fields::Unnamed(ref fields) => {
@@ -248,6 +266,12 @@ fn derive_serialize_impl(
                             serialize_where
                                 .predicates
                                 .push(serialize_bound(&rkyv_path, field)?);
+
+                            if let Some(remote_clause) =
+                                serialize_remote_bound(&rkyv_path, field)?
+                            {
+                                serialize_where.predicates.push(remote_clause);
+                            }
                         }
                     }
                     Fields::Unit => (),

--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -6,7 +6,7 @@ use syn::{
 
 use crate::{
     attributes::Attributes,
-    util::{is_not_omitted, remote_field_access, serialize, serialize_bound, serialize_remote, serialize_remote_bound, strip_raw},
+    util::{is_not_omitted, remote_field_access, serialize, serialize_bound, serialize_remote, serialize_remote_bound, strip_generics_from_path, strip_raw},
 };
 
 pub fn derive(input: DeriveInput) -> Result<TokenStream, Error> {
@@ -325,7 +325,7 @@ fn derive_serialize_impl(
                     data,
                     &rkyv_path,
                     &resolver,
-                    remote,
+                    &strip_generics_from_path(remote.clone()),
                     serialize_remote
                 )?;
 

--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -400,7 +400,7 @@ fn generate_serialize_arms(
                         .collect::<Result<Vec<_>, Error>>()?;
                     Ok(quote! {
                         #name::#variant {
-                            #(#bindings,)*
+                            #(#bindings,)* ..
                         } => #resolver::#variant {
                             #(#fields,)*
                         }
@@ -432,7 +432,7 @@ fn generate_serialize_arms(
                         .collect::<Result<Vec<_>, Error>>()?;
                     Ok(quote! {
                         #name::#variant(
-                            #(#bindings,)*
+                            #(#bindings,)* ..
                         ) => #resolver::#variant(#(#fields,)*)
                     })
                 }

--- a/rkyv_derive/src/util.rs
+++ b/rkyv_derive/src/util.rs
@@ -7,7 +7,8 @@ use syn::{
     parse_quote,
     punctuated::Iter,
     token, Data, DataEnum, DataStruct, DataUnion, Error, Field, Ident,
-    MacroDelimiter, Meta, MetaList, Path, Token, Type, Variant, WherePredicate,
+    MacroDelimiter, Meta, MetaList, Path, PathArguments, Token, Type, Variant,
+    WherePredicate,
 };
 
 pub fn try_set_attribute<T: ToTokens>(
@@ -616,4 +617,12 @@ pub fn remote_field_access(
     }
 
     Ok(quote!(&field.#member))
+}
+
+pub fn strip_generics_from_path(mut path: Path) -> Path {
+    for segment in path.segments.iter_mut() {
+        segment.arguments = PathArguments::None;
+    }
+
+    path
 }

--- a/rkyv_derive/src/util.rs
+++ b/rkyv_derive/src/util.rs
@@ -3,7 +3,11 @@ use core::iter::FlatMap;
 use proc_macro2::{Delimiter, Span, TokenStream, TokenTree};
 use quote::{quote, ToTokens};
 use syn::{
-    parse::{Parse, ParseStream}, parse_quote, punctuated::Iter, token, Data, DataEnum, DataStruct, DataUnion, Error, Field, Ident, MacroDelimiter, Meta, MetaList, Path, Token, Type, Variant, WherePredicate
+    parse::{Parse, ParseStream},
+    parse_quote,
+    punctuated::Iter,
+    token, Data, DataEnum, DataStruct, DataUnion, Error, Field, Ident,
+    MacroDelimiter, Meta, MetaList, Path, Token, Type, Variant, WherePredicate,
 };
 
 pub fn try_set_attribute<T: ToTokens>(
@@ -341,8 +345,12 @@ pub fn archive_remote_bound(
                 parse_quote! {
                     #remote_with_ty: #rkyv_path::with::ArchiveWith<
                         #remote_ty,
-                        Archived = <#with_ty as #rkyv_path::with::ArchiveWith<#ty>>::Archived,
-                        Resolver = <#with_ty as #rkyv_path::with::ArchiveWith<#ty>>::Resolver,
+                        Archived = <
+                            #with_ty as #rkyv_path::with::ArchiveWith<#ty>
+                        >::Archived,
+                        Resolver = <
+                            #with_ty as #rkyv_path::with::ArchiveWith<#ty>
+                        >::Resolver,
                     >
                 }
             } else {
@@ -394,8 +402,12 @@ pub fn serialize_remote_bound(
                     #remote_with_ty: #rkyv_path::with::SerializeWith<
                         #remote_ty,
                         __S,
-                        Archived = <#with_ty as #rkyv_path::with::ArchiveWith<#ty>>::Archived,
-                        Resolver = <#with_ty as #rkyv_path::with::ArchiveWith<#ty>>::Resolver,
+                        Archived = <
+                            #with_ty as #rkyv_path::with::ArchiveWith<#ty>
+                        >::Archived,
+                        Resolver = <
+                            #with_ty as #rkyv_path::with::ArchiveWith<#ty>
+                        >::Resolver,
                     >
                 }
             } else {
@@ -425,7 +437,11 @@ pub fn deserialize_bound(
         field,
         |with_ty| {
             parse_quote! {
-                #with_ty: #rkyv_path::with::DeserializeWith<#archived, #ty, __D>
+                #with_ty: #rkyv_path::with::DeserializeWith<
+                    #archived,
+                    #ty,
+                    __D,
+                >
             }
         },
         || {
@@ -475,7 +491,9 @@ fn archive_remote_item(
             let ident = Ident::new(with_name, Span::call_site());
             quote! {
                 <
-                    #remote_with_ty as #rkyv_path::with::ArchiveWith<#remote_ty>
+                    #remote_with_ty as #rkyv_path::with::ArchiveWith<
+                        #remote_ty
+                    >
                 >::#ident
             }
         },
@@ -541,7 +559,10 @@ pub fn serialize_remote(
         |_with_ty, remote_ty, remote_with_ty| {
             quote! {
                 <
-                    #remote_with_ty as #rkyv_path::with::SerializeWith<#remote_ty, __S>
+                    #remote_with_ty as #rkyv_path::with::SerializeWith<
+                        #remote_ty,
+                        __S,
+                    >
                 >::serialize_with
             }
         },
@@ -582,7 +603,10 @@ pub fn deserialize(
     )
 }
 
-pub fn remote_field_access(field: &Field, member: &impl ToTokens) -> Result<TokenStream, Error> {
+pub fn remote_field_access(
+    field: &Field,
+    member: &impl ToTokens,
+) -> Result<TokenStream, Error> {
     let with = With::from_field(field)?;
 
     if let Some(remote) = with.remote {

--- a/rkyv_derive/src/util.rs
+++ b/rkyv_derive/src/util.rs
@@ -3,11 +3,7 @@ use core::iter::FlatMap;
 use proc_macro2::{Delimiter, Span, TokenStream, TokenTree};
 use quote::{quote, ToTokens};
 use syn::{
-    parse::{Parse, ParseStream},
-    parse_quote,
-    punctuated::Iter,
-    token, Data, DataEnum, DataStruct, DataUnion, Error, Field, Ident,
-    MacroDelimiter, Meta, MetaList, Path, Token, Type, Variant, WherePredicate,
+    parse::{Parse, ParseStream}, parse_quote, punctuated::Iter, token, Data, DataEnum, DataStruct, DataUnion, Error, Field, Ident, MacroDelimiter, Member, Meta, MetaList, Path, Token, Type, Variant, WherePredicate
 };
 
 pub fn try_set_attribute<T: ToTokens>(
@@ -559,4 +555,16 @@ pub fn deserialize(
             }
         },
     )
+}
+
+pub fn remote_field_access(field: &Field, member: &Member) -> Result<TokenStream, Error> {
+    let with = With::from_field(field)?;
+
+    if let Some(remote) = with.remote {
+        if let Some(getter) = remote.getter {
+            return Ok(quote!(&#getter(field)));
+        }
+    }
+
+    Ok(quote!(&field.#member))
 }

--- a/rkyv_derive/src/util.rs
+++ b/rkyv_derive/src/util.rs
@@ -135,11 +135,11 @@ impl Parse for TypeOrMeta {
                     }
                 })?;
 
-                return Ok(Self::List(MetaList {
+                Ok(Self::List(MetaList {
                     path: ty_path.path,
                     delimiter,
                     tokens,
-                }));
+                }))
             }
             Type::Path(ty_path) if input.peek(Token![=]) => {
                 input.parse::<Token![=]>()?;


### PR DESCRIPTION
This adds the ability to put `#[rkyv(remote = Type)]` on container definitions `T` which implements
- `ArchiveWith<Type> for T` with the `Archive` macro
- `SerializeWith<Type, _> for T` with the `Serialize` macro
- `DeserializeWith<Archived<T>, Type, _> for T` with the `Deserialize` macro

The `#[with(...)]` attribute on fields is extended to accept a comma-separated list of either `Type` (just like before) or `remote(...)` which configures the `*With` implementations.

The `remote(...)` item accepts a comma-separated list of
- `Type` which needs to be specified if the remote field's type is different
- `with = Type` to specify a with-wrapper to convert from the remote field's type
- `getter = Path` to specify a path to a function of signature `fn(&RemoteType) -> &RemoteFieldType` or `fn(&RemoteType) -> RemoteFieldType` which is required if the remote field is private.

The namings are inspired by serde's way of [handling remote types](https://serde.rs/remote-derive.html).

Deriving `Deserialize` for `T` with `#[rkyv(remote = R)]` requires a `From<T> for R` implementation.

## Checklist

- [x] Add tests (`/rkyv/tests/derive.rs`)
- [x] Parse macro attributes
- [x] Implement traits
- [ ] Add documentation
- [ ] Add examples