### PR TITLE
Fix `Result::Ok` variant path

### DIFF
--- a/rkyv_derive/src/deserialize.rs
+++ b/rkyv_derive/src/deserialize.rs
@@ -89,7 +89,7 @@ fn derive_deserialize_impl(
                             #name #ty_generics,
                             <__D as #rkyv_path::rancor::Fallible>::Error,
                         > {
-                            Ok(#name {
+                            ::core::result::Result::Ok(#name {
                                 #(#deserialize_fields,)*
                             })
                         }
@@ -136,7 +136,7 @@ fn derive_deserialize_impl(
                             #name #ty_generics,
                             <__D as #rkyv_path::rancor::Fallible>::Error,
                         > {
-                            Ok(#name(
+                            ::core::result::Result::Ok(#name(
                                 #(#deserialize_fields,)*
                             ))
                         }
@@ -156,7 +156,7 @@ fn derive_deserialize_impl(
                         #name #ty_generics,
                         <__D as #rkyv_path::rancor::Fallible>::Error,
                     > {
-                        Ok(#name)
+                        ::core::result::Result::Ok(#name)
                     }
                 }
             },
@@ -276,7 +276,7 @@ fn derive_deserialize_impl(
                         #name #ty_generics,
                         <__D as #rkyv_path::rancor::Fallible>::Error,
                     > {
-                        Ok(match self {
+                        ::core::result::Result::Ok(match self {
                             #(#deserialize_variants,)*
                         })
                     }

--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -85,7 +85,7 @@ fn derive_serialize_impl(
                                 Self::Resolver,
                                 <__S as #rkyv_path::rancor::Fallible>::Error,
                             > {
-                                Ok(#resolver {
+                                ::core::result::Result::Ok(#resolver {
                                     #(#resolver_values,)*
                                 })
                             }
@@ -123,7 +123,7 @@ fn derive_serialize_impl(
                                 Self::Resolver,
                                 <__S as #rkyv_path::rancor::Fallible>::Error,
                             > {
-                                Ok(#resolver(
+                                ::core::result::Result::Ok(#resolver(
                                     #(#resolver_values,)*
                                 ))
                             }
@@ -143,7 +143,7 @@ fn derive_serialize_impl(
                                 Self::Resolver,
                                 <__S as #rkyv_path::rancor::Fallible>::Error,
                             > {
-                                Ok(#resolver)
+                                ::core::result::Result::Ok(#resolver)
                             }
                         }
                     }
@@ -241,7 +241,7 @@ fn derive_serialize_impl(
                             <Self as #rkyv_path::Archive>::Resolver,
                             <__S as #rkyv_path::rancor::Fallible>::Error,
                         > {
-                            Ok(match self {
+                            ::core::result::Result::Ok(match self {
                                 #(#serialize_arms,)*
                             })
                         }


### PR DESCRIPTION
In `rkyv_derive` full path is defined for `Result` but not for `Result::Ok`. It leads to possible name conflicts like with `eyre` crate. If user uses `use eyre::*;`,  `eyre::Ok` is also imported. In this case derive macro errors.