### PR TITLE
Implement `*With` traits via derive macros (continued)

### DIFF
--- a/rkyv/tests/derive.rs
+++ b/rkyv/tests/derive.rs
@@ -131,6 +131,12 @@ fn unit_struct() {
     #[rkyv(remote = Remote)]
     struct Example;
 
+    impl From<Example> for Remote {
+        fn from(_: Example) -> Self {
+            Self
+        }
+    }
+
     let remote = Remote;
     roundtrip::<Example, _>(&remote);
 }

--- a/rkyv/tests/derive.rs
+++ b/rkyv/tests/derive.rs
@@ -1,0 +1,476 @@
+use std::{fmt::Debug, marker::PhantomData, mem::MaybeUninit};
+
+use rancor::{Fallible, Panic, ResultExt, Source, Strategy};
+use rkyv::{
+    api::low::LowSerializer,
+    ser::{allocator::SubAllocator, writer::Buffer, Writer},
+    with::{ArchiveWith, DeserializeWith, Map, SerializeWith},
+    Archive, Archived, Deserialize, Place, Resolver, Serialize,
+};
+
+type ArchivedWith<F, T> = <F as ArchiveWith<T>>::Archived;
+
+fn roundtrip<F, T>(remote: &T)
+where
+    F: ArchiveWith<T, Archived: CheckedArchived>
+        + for<'a, 'b> SerializeWith<T, Serializer<'a, 'b>>
+        + DeserializeWith<ArchivedWith<F, T>, T, Strategy<(), Panic>>,
+    T: Debug + PartialEq,
+{
+    let mut bytes = [0_u8; 128];
+    let buf = serialize::<F, T>(remote, &mut bytes);
+    let archived = access::<F, T>(&buf);
+    let deserialized: T =
+        F::deserialize_with(archived, Strategy::wrap(&mut ())).always_ok();
+
+    assert_eq!(remote, &deserialized);
+}
+
+#[test]
+fn named_struct() {
+    #[derive(Debug, PartialEq)]
+    struct Remote<'a, A> {
+        a: u8,
+        b: PhantomData<&'a A>,
+        c: Option<Foo>,
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = Remote<'a, A>)]
+    struct Example<'a, A> {
+        a: u8,
+        #[rkyv(with = Identity)]
+        b: PhantomData<&'a A>,
+        #[rkyv(with = Map<FooWrap>)]
+        c: Option<Foo>,
+    }
+
+    impl<'a, A> From<Example<'a, A>> for Remote<'a, A> {
+        fn from(value: Example<'a, A>) -> Self {
+            Remote {
+                a: value.a,
+                b: value.b,
+                c: value.c,
+            }
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = Remote<'a, A>)]
+    struct Partial<'a, A> {
+        b: PhantomData<&'a A>,
+        #[rkyv(with = Map<FooWrap>)]
+        c: Option<Foo>,
+    }
+
+    impl<'a, A> From<Partial<'a, A>> for Remote<'a, A> {
+        fn from(archived: Partial<'a, A>) -> Self {
+            Self {
+                a: 42,
+                b: archived.b,
+                c: archived.c,
+            }
+        }
+    }
+
+    let remote = Remote {
+        a: 42,
+        b: PhantomData,
+        c: Some(Foo::default()),
+    };
+
+    roundtrip::<Example<i32>, _>(&remote);
+    roundtrip::<Partial<i32>, _>(&remote);
+}
+
+#[test]
+fn unnamed_struct() {
+    #[derive(Debug, PartialEq)]
+    struct Remote<'a, A>(u8, PhantomData<&'a A>, Option<Foo>);
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = Remote::<'a, A>)]
+    struct Example<'a, A>(
+        u8,
+        #[rkyv(with = Identity)] PhantomData<&'a A>,
+        #[rkyv(with = Map<FooWrap>)] Option<Foo>,
+    );
+
+    impl<'a, A> From<Example<'a, A>> for Remote<'a, A> {
+        fn from(value: Example<'a, A>) -> Self {
+            Remote(value.0, value.1, value.2)
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = Remote::<'a, A>)]
+    struct Partial<'a, A>(
+        u8,
+        #[rkyv(with = Identity)] PhantomData<&'a A>,
+        // Only trailing fields may be omitted for unnamed structs
+    );
+
+    impl<'a, A> From<Partial<'a, A>> for Remote<'a, A> {
+        fn from(archived: Partial<'a, A>) -> Self {
+            Remote(archived.0, archived.1, Some(Foo::default()))
+        }
+    }
+
+    let remote = Remote(42, PhantomData, Some(Foo::default()));
+
+    roundtrip::<Example<i32>, _>(&remote);
+    roundtrip::<Partial<i32>, _>(&remote);
+}
+
+#[test]
+fn unit_struct() {
+    #[derive(Debug, PartialEq)]
+    struct Remote;
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = Remote)]
+    struct Example;
+
+    let remote = Remote;
+    roundtrip::<Example, _>(&remote);
+}
+
+#[test]
+fn full_enum() {
+    #[derive(Debug, PartialEq)]
+    enum Remote<'a, A> {
+        A,
+        B(u8),
+        C {
+            a: PhantomData<&'a A>,
+            b: Option<Foo>,
+        },
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = Remote::<'a, A>)]
+    enum Example<'a, A> {
+        A,
+        B(u8),
+        C {
+            #[rkyv(with = Identity)]
+            a: PhantomData<&'a A>,
+            #[rkyv(with = Map<FooWrap>)]
+            b: Option<Foo>,
+        },
+    }
+
+    impl<'a, A> From<Example<'a, A>> for Remote<'a, A> {
+        fn from(value: Example<'a, A>) -> Self {
+            match value {
+                Example::A => Remote::A,
+                Example::B(value) => Remote::B(value),
+                Example::C { a, b } => Remote::C { a, b },
+            }
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = Remote::<'a, A>)]
+    // Variant fields may be omitted but no variants themselves
+    enum Partial<'a, A> {
+        A,
+        B(),
+        C { a: PhantomData<&'a A> },
+    }
+
+    impl<'a, A> From<Partial<'a, A>> for Remote<'a, A> {
+        fn from(archived: Partial<'a, A>) -> Self {
+            match archived {
+                Partial::A => Remote::A,
+                Partial::B() => Remote::B(42),
+                Partial::C { a } => Remote::C {
+                    a,
+                    b: Some(Foo::default()),
+                },
+            }
+        }
+    }
+
+    for remote in [
+        Remote::A,
+        Remote::B(42),
+        Remote::C {
+            a: PhantomData,
+            b: Some(Foo::default()),
+        },
+    ] {
+        roundtrip::<Example<i32>, _>(&remote);
+        roundtrip::<Partial<i32>, _>(&remote);
+    }
+}
+
+#[test]
+fn named_struct_private() {
+    mod remote {
+        #[derive(Copy, Clone, Debug, Default, PartialEq)]
+        pub struct Remote {
+            inner: [u8; 4],
+        }
+
+        impl Remote {
+            pub fn new(inner: [u8; 4]) -> Self {
+                Self { inner }
+            }
+
+            pub fn inner(&self) -> [u8; 4] {
+                self.inner
+            }
+
+            pub fn inner_ref(&self) -> &[u8; 4] {
+                &self.inner
+            }
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = remote::Remote)]
+    struct ExampleByRef {
+        #[rkyv(getter = remote::Remote::inner)]
+        inner: [u8; 4],
+    }
+
+    impl From<ExampleByRef> for remote::Remote {
+        fn from(value: ExampleByRef) -> Self {
+            remote::Remote::new(value.inner)
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = remote::Remote)]
+    struct ExampleThroughRef {
+        #[rkyv(getter = remote::Remote::inner_ref)]
+        inner: [u8; 4],
+    }
+
+    impl From<ExampleThroughRef> for remote::Remote {
+        fn from(value: ExampleThroughRef) -> Self {
+            remote::Remote::new(value.inner)
+        }
+    }
+
+    let remote = remote::Remote::default();
+    roundtrip::<ExampleByRef, _>(&remote);
+    roundtrip::<ExampleThroughRef, _>(&remote);
+}
+
+#[test]
+fn unnamed_struct_private() {
+    mod remote {
+        #[derive(Copy, Clone, Debug, Default, PartialEq)]
+        pub struct Remote([u8; 4]);
+
+        impl Remote {
+            pub fn new(inner: [u8; 4]) -> Self {
+                Self(inner)
+            }
+
+            pub fn inner(&self) -> [u8; 4] {
+                self.0
+            }
+
+            pub fn inner_ref(&self) -> &[u8; 4] {
+                &self.0
+            }
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = remote::Remote)]
+    struct ExampleByRef(#[rkyv(getter = remote::Remote::inner)] [u8; 4]);
+
+    impl From<ExampleByRef> for remote::Remote {
+        fn from(value: ExampleByRef) -> Self {
+            remote::Remote::new(value.0)
+        }
+    }
+
+    #[derive(Archive, Serialize, Deserialize)]
+    #[rkyv(remote = remote::Remote)]
+    struct ExampleThroughRef(
+        #[rkyv(getter = remote::Remote::inner_ref)] [u8; 4],
+    );
+
+    impl From<ExampleThroughRef> for remote::Remote {
+        fn from(value: ExampleThroughRef) -> Self {
+            remote::Remote::new(value.0)
+        }
+    }
+
+    let remote = remote::Remote::default();
+    roundtrip::<ExampleByRef, _>(&remote);
+    roundtrip::<ExampleThroughRef, _>(&remote);
+}
+
+#[cfg(feature = "bytecheck")]
+pub trait CheckedArchived:
+    for<'a> rkyv::bytecheck::CheckBytes<rkyv::api::low::LowValidator<'a, Panic>>
+{
+}
+
+#[cfg(feature = "bytecheck")]
+impl<
+        Archived: for<'a> rkyv::bytecheck::CheckBytes<
+            rkyv::api::low::LowValidator<'a, Panic>,
+        >,
+    > CheckedArchived for Archived
+{
+}
+
+#[cfg(not(feature = "bytecheck"))]
+pub trait CheckedArchived {}
+
+#[cfg(not(feature = "bytecheck"))]
+impl<Archived> CheckedArchived for Archived {}
+
+type Serializer<'a, 'b> =
+    LowSerializer<'a, Buffer<'b>, SubAllocator<'a>, Panic>;
+
+fn serialize<'buf, F, T>(remote: &T, buf: &'buf mut [u8; 128]) -> Buffer<'buf>
+where
+    F: for<'a, 'b> SerializeWith<T, Serializer<'a, 'b>>,
+{
+    struct Wrap<'a, F, T>(&'a T, PhantomData<F>);
+
+    impl<F, T> Archive for Wrap<'_, F, T>
+    where
+        F: ArchiveWith<T>,
+    {
+        type Archived = <F as ArchiveWith<T>>::Archived;
+        type Resolver = <F as ArchiveWith<T>>::Resolver;
+
+        fn resolve(
+            &self,
+            resolver: Self::Resolver,
+            out: Place<Self::Archived>,
+        ) {
+            F::resolve_with(self.0, resolver, out)
+        }
+    }
+
+    impl<'a, 'b, F, T> Serialize<Serializer<'a, 'b>> for Wrap<'_, F, T>
+    where
+        F: SerializeWith<T, Serializer<'a, 'b>>,
+    {
+        fn serialize(
+            &self,
+            serializer: &mut Serializer<'a, 'b>,
+        ) -> Result<Self::Resolver, Panic> {
+            F::serialize_with(self.0, serializer)
+        }
+    }
+
+    let wrap = Wrap(remote, PhantomData::<F>);
+    let writer = Buffer::from(buf);
+    let mut scratch = [MaybeUninit::uninit(); 128];
+    let alloc = SubAllocator::new(&mut scratch);
+
+    rkyv::api::low::to_bytes_in_with_alloc::<_, _, Panic>(&wrap, writer, alloc)
+        .always_ok()
+}
+
+fn access<F, T>(bytes: &[u8]) -> &<F as ArchiveWith<T>>::Archived
+where
+    F: ArchiveWith<T, Archived: CheckedArchived>,
+{
+    #[cfg(feature = "bytecheck")]
+    {
+        rkyv::api::low::access::<<F as ArchiveWith<T>>::Archived, Panic>(bytes)
+            .always_ok()
+    }
+
+    #[cfg(not(feature = "bytecheck"))]
+    unsafe {
+        rkyv::access_unchecked::<<F as ArchiveWith<T>>::Archived>(bytes)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct Foo([u8; 4]);
+
+impl Default for Foo {
+    fn default() -> Self {
+        Self([2, 3, 5, 7])
+    }
+}
+
+struct FooWrap;
+
+impl ArchiveWith<Foo> for FooWrap {
+    type Archived = Archived<[u8; 4]>;
+    type Resolver = Resolver<[u8; 4]>;
+
+    fn resolve_with(
+        field: &Foo,
+        resolver: Self::Resolver,
+        out: Place<Self::Archived>,
+    ) {
+        field.0.resolve(resolver, out);
+    }
+}
+
+impl<S> SerializeWith<Foo, S> for FooWrap
+where
+    S: Fallible<Error: Source> + Writer + ?Sized,
+{
+    fn serialize_with(
+        field: &Foo,
+        serializer: &mut S,
+    ) -> Result<Self::Resolver, S::Error> {
+        field.0.serialize(serializer)
+    }
+}
+
+impl<D: Fallible + ?Sized> DeserializeWith<Archived<[u8; 4]>, Foo, D>
+    for FooWrap
+{
+    fn deserialize_with(
+        archived: &Archived<[u8; 4]>,
+        deserializer: &mut D,
+    ) -> Result<Foo, D::Error> {
+        archived.deserialize(deserializer).map(Foo)
+    }
+}
+
+struct Identity;
+
+impl<T: Archive> ArchiveWith<T> for Identity {
+    type Archived = Archived<T>;
+    type Resolver = Resolver<T>;
+
+    fn resolve_with(
+        this: &T,
+        resolver: Self::Resolver,
+        out: Place<Self::Archived>,
+    ) {
+        this.resolve(resolver, out);
+    }
+}
+
+impl<S: Fallible + ?Sized, T: Serialize<S>> SerializeWith<T, S> for Identity {
+    fn serialize_with(
+        this: &T,
+        serializer: &mut S,
+    ) -> Result<Self::Resolver, <S as Fallible>::Error> {
+        this.serialize(serializer)
+    }
+}
+
+impl<D, T> DeserializeWith<Archived<T>, T, D> for Identity
+where
+    D: Fallible + ?Sized,
+    T: Archive,
+    Archived<T>: Deserialize<T, D>,
+{
+    fn deserialize_with(
+        archived: &Archived<T>,
+        deserializer: &mut D,
+    ) -> Result<T, <D as Fallible>::Error> {
+        archived.deserialize(deserializer)
+    }
+}

--- a/rkyv_derive/src/archive/mod.rs
+++ b/rkyv_derive/src/archive/mod.rs
@@ -1,5 +1,5 @@
 mod r#enum;
-mod printing;
+pub mod printing;
 mod r#struct;
 
 use proc_macro2::{Span, TokenStream};

--- a/rkyv_derive/src/archive/mod.rs
+++ b/rkyv_derive/src/archive/mod.rs
@@ -6,7 +6,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
     parse_quote, Data, DataStruct, DeriveInput, Error, Field, Ident, Meta,
-    Token, Type,
+    Path, Token, Type,
 };
 
 use crate::{
@@ -46,9 +46,14 @@ fn archive_field_metas<'a>(
                 meta.input.parse::<Token![=]>()?;
                 meta.input.parse::<Type>()?;
                 Ok(())
+            } else if meta.path.is_ident("getter") {
+                meta.input.parse::<Token![=]>()?;
+                meta.input.parse::<Path>()?;
+                Ok(())
             } else {
                 Err(meta.error(
-                    "unrecognized argument; expected `omit_bounds` or `attr`",
+                    "unrecognized argument; expected `omit_bounds`, `attr`, \
+                     or `getter`",
                 ))
             }
         })?;

--- a/rkyv_derive/src/attributes.rs
+++ b/rkyv_derive/src/attributes.rs
@@ -370,4 +370,16 @@ impl FieldAttributes {
             }
         }
     }
+
+    pub fn access_field(
+        &self,
+        this: &Ident,
+        member: &impl ToTokens,
+    ) -> TokenStream {
+        if let Some(ref getter) = self.getter {
+            quote! { &#getter(&#this) }
+        } else {
+            quote! { &#this.#member }
+        }
+    }
 }

--- a/rkyv_derive/src/attributes.rs
+++ b/rkyv_derive/src/attributes.rs
@@ -27,6 +27,7 @@ pub struct Attributes {
     pub as_type: Option<Type>,
     pub archived: Option<Ident>,
     pub resolver: Option<Ident>,
+    pub remote: Option<Path>,
     pub metas: Vec<Meta>,
     pub compares: Option<Punctuated<Path, Token![,]>>,
     pub archive_bounds: Option<Punctuated<WherePredicate, Token![,]>>,
@@ -137,6 +138,12 @@ impl Attributes {
             self.metas
                 .extend(metas.parse_terminated(Meta::parse, Token![,])?);
             Ok(())
+        } else if meta.path.is_ident("remote") {
+            try_set_attribute(
+                &mut self.remote,
+                meta.value()?.parse()?,
+                "remote",
+            )
         } else {
             Err(meta.error("unrecognized rkyv argument"))
         }
@@ -192,6 +199,7 @@ pub struct FieldAttributes {
     pub attrs: Punctuated<Meta, Token![,]>,
     pub omit_bounds: Option<Path>,
     pub with: Option<Type>,
+    pub getter: Option<Path>,
 }
 
 impl FieldAttributes {
@@ -207,6 +215,10 @@ impl FieldAttributes {
         } else if meta.path.is_ident("with") {
             meta.input.parse::<Token![=]>()?;
             self.with = Some(meta.input.parse::<Type>()?);
+            Ok(())
+        } else if meta.path.is_ident("getter") {
+            meta.input.parse::<Token![=]>()?;
+            self.getter = Some(meta.input.parse::<Path>()?);
             Ok(())
         } else {
             Err(meta.error("unrecognized rkyv arguments"))

--- a/rkyv_derive/src/deserialize.rs
+++ b/rkyv_derive/src/deserialize.rs
@@ -141,15 +141,15 @@ fn generate_deserialize_body(
                         let field_attrs = FieldAttributes::parse(field)?;
 
                         deserialize_where.predicates.extend(
-                            field_attrs.archive_bound(&rkyv_path, field),
+                            field_attrs.archive_bound(rkyv_path, field),
                         );
                         deserialize_where.predicates.extend(
-                            field_attrs.deserialize_bound(&rkyv_path, field),
+                            field_attrs.deserialize_bound(rkyv_path, field),
                         );
 
                         let name = &field.ident;
                         let deserialize =
-                            field_attrs.deserialize(&rkyv_path, field);
+                            field_attrs.deserialize(rkyv_path, field);
                         Ok(quote! {
                             #name: #deserialize(&#this.#name, deserializer)?
                         })
@@ -167,15 +167,15 @@ fn generate_deserialize_body(
                         let field_attrs = FieldAttributes::parse(field)?;
 
                         deserialize_where.predicates.extend(
-                            field_attrs.archive_bound(&rkyv_path, field),
+                            field_attrs.archive_bound(rkyv_path, field),
                         );
                         deserialize_where.predicates.extend(
-                            field_attrs.deserialize_bound(&rkyv_path, field),
+                            field_attrs.deserialize_bound(rkyv_path, field),
                         );
 
                         let index = Index::from(i);
                         let deserialize =
-                            field_attrs.deserialize(&rkyv_path, field);
+                            field_attrs.deserialize(rkyv_path, field);
                         Ok(quote! {
                             #deserialize(&#this.#index, deserializer)?
                         })
@@ -207,17 +207,17 @@ fn generate_deserialize_body(
 
                                     deserialize_where.predicates.extend(
                                         field_attrs
-                                            .archive_bound(&rkyv_path, field),
+                                            .archive_bound(rkyv_path, field),
                                     );
                                     deserialize_where.predicates.extend(
                                         field_attrs.deserialize_bound(
-                                            &rkyv_path, field,
+                                            rkyv_path, field,
                                         ),
                                     );
 
                                     let name = &field.ident;
                                     let deserialize = field_attrs
-                                        .deserialize(&rkyv_path, field);
+                                        .deserialize(rkyv_path, field);
                                     Ok(quote! {
                                         #name: #deserialize(
                                             #name,
@@ -249,11 +249,11 @@ fn generate_deserialize_body(
 
                                     deserialize_where.predicates.extend(
                                         field_attrs
-                                            .archive_bound(&rkyv_path, field),
+                                            .archive_bound(rkyv_path, field),
                                     );
                                     deserialize_where.predicates.extend(
                                         field_attrs.deserialize_bound(
-                                            &rkyv_path, field,
+                                            rkyv_path, field,
                                         ),
                                     );
 
@@ -262,7 +262,7 @@ fn generate_deserialize_body(
                                         field.span(),
                                     );
                                     let deserialize = field_attrs
-                                        .deserialize(&rkyv_path, field);
+                                        .deserialize(rkyv_path, field);
                                     Ok(quote! {
                                         #deserialize(
                                             #binding,

--- a/rkyv_derive/src/deserialize.rs
+++ b/rkyv_derive/src/deserialize.rs
@@ -277,9 +277,9 @@ fn generate_deserialize_body(
                                 ) => #return_type::#variant(#(#fields,)*)
                             })
                         }
-                        Fields::Unit => Ok(
-                            quote! { #self_type::#variant => #return_type::#variant },
-                        ),
+                        Fields::Unit => Ok(quote! {
+                            #self_type::#variant => #return_type::#variant
+                        }),
                     }
                 })
                 .collect::<Result<Vec<_>, Error>>()?;

--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -133,14 +133,13 @@ fn generate_serialize_body(
                         let field_attrs = FieldAttributes::parse(field)?;
 
                         serialize_where.predicates.extend(
-                            field_attrs.serialize_bound(&rkyv_path, field),
+                            field_attrs.serialize_bound(rkyv_path, field),
                         );
 
                         let name = &field.ident;
                         let access_field =
                             field_attrs.access_field(&this, name);
-                        let serialize =
-                            field_attrs.serialize(&rkyv_path, field);
+                        let serialize = field_attrs.serialize(rkyv_path, field);
                         Ok(quote! {
                             #name: #serialize(#access_field, serializer)?
                         })
@@ -158,14 +157,13 @@ fn generate_serialize_body(
                         let field_attrs = FieldAttributes::parse(field)?;
 
                         serialize_where.predicates.extend(
-                            field_attrs.serialize_bound(&rkyv_path, field),
+                            field_attrs.serialize_bound(rkyv_path, field),
                         );
 
                         let index = Index::from(i);
                         let access_field =
                             field_attrs.access_field(&this, &index);
-                        let serialize =
-                            field_attrs.serialize(&rkyv_path, field);
+                        let serialize = field_attrs.serialize(rkyv_path, field);
                         Ok(quote! { #serialize(#access_field, serializer)? })
                     })
                     .collect::<Result<Vec<_>, Error>>()?;
@@ -191,15 +189,14 @@ fn generate_serialize_body(
                                     let field_attrs =
                                         FieldAttributes::parse(field)?;
 
-                                    serialize_where
-                                        .predicates
-                                        .extend(field_attrs.serialize_bound(
-                                            &rkyv_path, field,
-                                        ));
+                                    serialize_where.predicates.extend(
+                                        field_attrs
+                                            .serialize_bound(rkyv_path, field),
+                                    );
 
                                     let name = &field.ident;
-                                    let serialize = field_attrs
-                                        .serialize(&rkyv_path, field);
+                                    let serialize =
+                                        field_attrs.serialize(rkyv_path, field);
                                     Ok(quote! {
                                         #name: #serialize(#name, serializer)?
                                     })
@@ -229,18 +226,17 @@ fn generate_serialize_body(
                                     let field_attrs =
                                         FieldAttributes::parse(field)?;
 
-                                    serialize_where
-                                        .predicates
-                                        .extend(field_attrs.serialize_bound(
-                                            &rkyv_path, field,
-                                        ));
+                                    serialize_where.predicates.extend(
+                                        field_attrs
+                                            .serialize_bound(rkyv_path, field),
+                                    );
 
                                     let binding = Ident::new(
                                         &format!("_{}", i),
                                         field.span(),
                                     );
-                                    let serialize = field_attrs
-                                        .serialize(&rkyv_path, field);
+                                    let serialize =
+                                        field_attrs.serialize(rkyv_path, field);
                                     Ok(quote! {
                                         #serialize(#binding, serializer)?
                                     })

--- a/rkyv_derive/src/util.rs
+++ b/rkyv_derive/src/util.rs
@@ -2,7 +2,8 @@ use core::iter::FlatMap;
 
 use proc_macro2::Ident;
 use syn::{
-    punctuated::Iter, Data, DataEnum, DataStruct, DataUnion, Field, Variant,
+    punctuated::Iter, Data, DataEnum, DataStruct, DataUnion, Field, Path,
+    PathArguments, Variant,
 };
 
 pub fn strip_raw(ident: &Ident) -> String {
@@ -47,4 +48,12 @@ pub fn iter_fields(data: &Data) -> FieldsIter<'_> {
             FieldsIter::Struct(fields.named.iter())
         }
     }
+}
+
+pub fn strip_generics_from_path(mut path: Path) -> Path {
+    for segment in path.segments.iter_mut() {
+        segment.arguments = PathArguments::None;
+    }
+
+    path
 }


### PR DESCRIPTION
Continuation of #539 

Adding `#[rkyv(remote = Type)]` on container definitions will implement `ArchiveWith`/`SerializeWith`/`DeserializeWith` instead of `Archive`/`Serialize`/`Deserialize`.

The attribute `#[rkyv(getter = path::to::function)]` can be used to access private fields of the remote type.