### PR TITLE
fix: minimum `syn` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rkyv = { version = "0.8", default-features = false, path = "rkyv" }
 rkyv_derive = { version = "=0.8.2", default-features = false, path = "rkyv_derive" }
 # rkyv_dyn = { version = "=0.8.0-rc.1", default-features = false, path = "rkyv_dyn" }
 # rkyv_dyn_derive = { version = "=0.8.0-rc.1", default-features = false, path = "rkyv_dyn_derive" }
-syn = { version = "2", default-features = false }
+syn = { version = "2.0.73", default-features = false }
 trybuild = { version = "1", default-features = false }
 
 [patch.crates-io]


### PR DESCRIPTION
`rkyv` uses `Fields::members()` which was added in `syn` [v2.0.73](https://github.com/dtolnay/syn/releases/tag/2.0.73) (not a very correct use of SemVer on `syn`'s part). Downstream projects that have locked `syn` to an older version would fail to compile upon adding `rkyv` as a dependency.

This can be reproduced by just trying to compile:

```toml
[package]
name = "rkyv-test"
version = "0.1.0"
edition = "2021"

[dependencies]
rkyv = "0.8.2"
syn = "=2.0.72"
```