### PR TITLE
Support missing enum variants on remote derives

### DIFF
--- a/rkyv/examples/remote_types.rs
+++ b/rkyv/examples/remote_types.rs
@@ -116,3 +116,32 @@ fn main() -> Result<(), Failure> {
 
     Ok(())
 }
+
+#[allow(unused)]
+mod another_remote {
+    // Another remote type, this time an enum.
+    #[non_exhaustive] // <- notice this inconvenience too
+    pub enum Qux {
+        Unit,
+        Tuple(i32),
+        Struct { value: bool },
+    }
+}
+
+#[allow(unused)]
+// Enums work similarly
+#[derive(Archive, Serialize)]
+#[rkyv(remote = another_remote::Qux)]
+enum QuxDef {
+    // Variants must have the same name and type, e.g. a remote *tuple*
+    // variant requires a local *tuple* variant.
+    Unit,
+    // Same as for actual structs - fields of struct variants may be omitted.
+    Struct {},
+    // If `Serialize` should be derived and either the remote enum is
+    // `#[non_exhaustive]` or any of its variants were omitted (notice the
+    // `Tuple(i32)` variant is missing), then the last variant *must* be a
+    // unit variant with the `#[rkyv(other)]` attribute.
+    #[rkyv(other)]
+    Unknown,
+}

--- a/rkyv/tests/derive.rs
+++ b/rkyv/tests/derive.rs
@@ -178,22 +178,26 @@ fn full_enum() {
 
     #[derive(Archive, Serialize, Deserialize)]
     #[rkyv(remote = Remote::<'a, A>)]
-    // Variant fields may be omitted but no variants themselves
+    // If a variant is missing (or the remote type is `#[non_exhaustive]`), one
+    // *unit* variant must be denoted with `#[rkyv(other)]`.
     enum Partial<'a, A> {
         A,
-        B(),
-        C { a: PhantomData<&'a A> },
+        C {
+            a: PhantomData<&'a A>,
+        },
+        #[rkyv(other)]
+        Other,
     }
 
     impl<'a, A> From<Partial<'a, A>> for Remote<'a, A> {
         fn from(archived: Partial<'a, A>) -> Self {
             match archived {
                 Partial::A => Remote::A,
-                Partial::B() => Remote::B(42),
                 Partial::C { a } => Remote::C {
                     a,
                     b: Some(Foo::default()),
                 },
+                Partial::Other => Remote::B(42),
             }
         }
     }

--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -186,7 +186,8 @@ fn generate_serialize_body(
                     if let Some(ref other) = other {
                         return Err(Error::new_spanned(
                             other,
-                            "Only the very last variant may be denoted with `#[rkyv(other)]`",
+                            "Only the very last variant may be denoted with \
+                             `#[rkyv(other)]`",
                         ));
                     }
                     let variant_attrs =
@@ -269,7 +270,9 @@ fn generate_serialize_body(
                                 other = variant_attrs.other;
                                 Ok(quote! { _ => #resolver::#variant })
                             } else {
-                                Ok(quote! { #name::#variant => #resolver::#variant })
+                                Ok(quote! {
+                                    #name::#variant => #resolver::#variant
+                                })
                             }
                         }
                     }


### PR DESCRIPTION
When deriving `Serialize`, omitting variants from remote enums is currently not supported, neither are remote enums that are `#[non_exhaustive]`.

This PR solves these two by adding the `#[rkyv(other)]` attribute on enum variants. The attribute may be specified only once, namely on the very last variant which must be of unit type.

The attribute essentially adds a `_ => { ... }` match branch for serialization which needs to be at the bottom. The code can likely be refactored to lift that restriction but I figured it's fine to require users to put their catch-all variant at the bottom.