### PR TITLE
Adjust Niching trait

### DIFF
--- a/rkyv/src/impls/alloc/with/niching.rs
+++ b/rkyv/src/impls/alloc/with/niching.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 use rancor::Fallible;
 
 use crate::{
+    alloc::boxed::Box,
     niche::niching::{Niching, Null},
     traits::ArchivePointee,
     Archive, ArchiveUnsized, Archived, Place, RelPtr, Serialize,

--- a/rkyv/src/impls/core/with/mod.rs
+++ b/rkyv/src/impls/core/with/mod.rs
@@ -25,7 +25,7 @@ use rancor::Fallible;
 use crate::{
     boxed::{ArchivedBox, BoxResolver},
     niche::{
-        niched_option::NichedOption,
+        niched_option::{NichedOption, NichedOptionResolver},
         niching::Niching,
         option_nonzero::{
             ArchivedOptionNonZeroI128, ArchivedOptionNonZeroI16,
@@ -395,10 +395,10 @@ where
 impl<T, N> ArchiveWith<Option<T>> for Nicher<N>
 where
     T: Archive,
-    N: Niching<T::Archived> + ?Sized,
+    N: Niching<T> + ?Sized,
 {
     type Archived = NichedOption<T, N>;
-    type Resolver = Option<T::Resolver>;
+    type Resolver = NichedOptionResolver<T, N>;
 
     fn resolve_with(
         field: &Option<T>,
@@ -416,7 +416,7 @@ where
 impl<T, N, S> SerializeWith<Option<T>, S> for Nicher<N>
 where
     T: Serialize<S>,
-    N: Niching<T::Archived> + ?Sized,
+    N: Niching<T, Niched: Serialize<S>> + ?Sized,
     S: Fallible + ?Sized,
 {
     fn serialize_with(
@@ -430,7 +430,7 @@ where
 impl<T, N, D> DeserializeWith<NichedOption<T, N>, Option<T>, D> for Nicher<N>
 where
     T: Archive<Archived: Deserialize<T, D>>,
-    N: Niching<T::Archived> + ?Sized,
+    N: Niching<T> + ?Sized,
     D: Fallible + ?Sized,
 {
     fn deserialize_with(
@@ -444,7 +444,7 @@ where
 impl<T, N, D> Deserialize<Option<T>, D> for NichedOption<T, N>
 where
     T: Archive<Archived: Deserialize<T, D>>,
-    N: Niching<T::Archived> + ?Sized,
+    N: Niching<T> + ?Sized,
     D: Fallible + ?Sized,
 {
     fn deserialize(&self, deserializer: &mut D) -> Result<Option<T>, D::Error> {

--- a/rkyv/src/impls/core/with/niching.rs
+++ b/rkyv/src/impls/core/with/niching.rs
@@ -1,24 +1,24 @@
 use core::num::{
-    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128,
-    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8,
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize,
+    NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
 };
 
 use crate::{
     niche::niching::{NaN, Niching, Zero},
-    Archive, Archived, Place,
+    Archived,
 };
 
 macro_rules! impl_nonzero_zero_niching {
     ($nz:ty, $ar:ty) => {
-        unsafe impl Niching<Archived<$nz>> for Zero {
-            type Niched = Archived<$ar>;
+        unsafe impl Niching<$nz> for Zero {
+            type Niched = $ar;
 
-            fn is_niched(niched: &Self::Niched) -> bool {
-                *niched == 0
+            fn niched() -> Self::Niched {
+                0
             }
 
-            fn resolve_niched(out: Place<Self::Niched>) {
-                <$ar>::resolve(&0, (), out)
+            fn is_niched(niched: &Archived<Self::Niched>) -> bool {
+                *niched == 0
             }
         }
     };
@@ -29,24 +29,26 @@ impl_nonzero_zero_niching!(NonZeroU16, u16);
 impl_nonzero_zero_niching!(NonZeroU32, u32);
 impl_nonzero_zero_niching!(NonZeroU64, u64);
 impl_nonzero_zero_niching!(NonZeroU128, u128);
+impl_nonzero_zero_niching!(NonZeroUsize, usize);
 
 impl_nonzero_zero_niching!(NonZeroI8, i8);
 impl_nonzero_zero_niching!(NonZeroI16, i16);
 impl_nonzero_zero_niching!(NonZeroI32, i32);
 impl_nonzero_zero_niching!(NonZeroI64, i64);
 impl_nonzero_zero_niching!(NonZeroI128, i128);
+impl_nonzero_zero_niching!(NonZeroIsize, isize);
 
 macro_rules! impl_float_nan_niching {
     ($fl:ty) => {
-        unsafe impl Niching<Archived<$fl>> for NaN {
-            type Niched = Archived<$fl>;
+        unsafe impl Niching<$fl> for NaN {
+            type Niched = $fl;
 
-            fn is_niched(niched: &Self::Niched) -> bool {
-                niched.to_native().is_nan()
+            fn niched() -> Self::Niched {
+                <$fl>::NAN
             }
 
-            fn resolve_niched(out: Place<Self::Niched>) {
-                <$fl>::resolve(&<$fl>::NAN, (), out)
+            fn is_niched(niched: &Archived<Self::Niched>) -> bool {
+                niched.to_native().is_nan()
             }
         }
     };

--- a/rkyv/src/niche/niching.rs
+++ b/rkyv/src/niche/niching.rs
@@ -19,6 +19,7 @@ use crate::{Archive, Archived};
 /// # Example
 ///
 /// ```
+/// # use std::num::NonZeroU16;
 /// use rkyv::{
 ///     niche::niching::Niching, with::Nicher, Archive, Archived, Serialize,
 /// };
@@ -86,7 +87,10 @@ use crate::{Archive, Archived};
 /// ];
 /// let bytes = rkyv::to_bytes(&values)?;
 /// let archived = rkyv::access::<[ArchivedWithNiching; 2], _>(&bytes)?;
-/// assert_eq!(archived[0].field.as_ref(), Some(&Archived<789>));
+/// assert_eq!(
+///     archived[0].field.as_ref().map(|field| field.other),
+///     Some(789.into())
+/// );
 /// assert!(archived[1].field.is_none());
 /// # Ok(()) }
 /// ```

--- a/rkyv/src/niche/niching.rs
+++ b/rkyv/src/niche/niching.rs
@@ -2,73 +2,107 @@
 //!
 //! [`Nicher`]: crate::with::Nicher
 
-use crate::{Place, Portable};
+use crate::{Archive, Archived};
 
 /// A type that can be used to niche a value with [`Nicher`].
 ///
 /// # Safety
 ///
-/// For a union with two fields of type `Self::Niched` and `T`, it must always
-/// be safe to access the `Self::Niched` field.
+/// For a union with two fields of type `Archived<Self::Niched>` and
+/// `Archived<T>`, it must always be safe to access the `Archived<Self::Niched>`
+/// field.
 ///
 /// Additionally, if [`is_niched`] returns `false` when being passed such a
-/// union's `Self::Niched` field, it must be safe to access the `T` field.
+/// union's `Archived<Self::Niched>` field, it must be safe to access the
+/// `Archived<T>` field.
 ///
 /// # Example
 ///
 /// ```
 /// use rkyv::{
-///     niche::niching::Niching, with::Nicher, Archive, Archived, Place,
-///     Serialize,
+///     niche::niching::Niching, with::Nicher, Archive, Archived, Serialize,
 /// };
 ///
-/// // Let's make it so that `Some(1)` is niched into `None`.
-/// struct One;
-///
-/// // SAFETY: `Self::Niched` is the same as `T` so it's always valid to access
-/// // it within a union of the two. Furthermore, we can be sure that the `T`
-/// // field is safe to access if `is_niched` returns `false`.
-/// unsafe impl Niching<Archived<u32>> for One {
-///     type Niched = Archived<u32>;
-///
-///     fn is_niched(niched: &Self::Niched) -> bool {
-///         *niched == 1
-///     }
-///
-///     fn resolve_niched(out: Place<Self::Niched>) {
-///         u32::resolve(&1, (), out);
-///     }
+/// #[derive(Archive, Serialize)]
+/// struct Nichable {
+///     num: NonZeroU16, // <- we can use this for niching
+///     other: u64,
 /// }
 ///
 /// #[derive(Archive)]
-/// struct Basic(Option<u32>);
+/// struct WithoutNiching {
+///     field: Option<Nichable>, // <- wrapped in an `Option`
+/// }
 ///
 /// #[derive(Archive, Serialize)]
-/// struct Niched(#[rkyv(with = Nicher<One>)] Option<u32>);
+/// struct WithNiching {
+///     #[rkyv(with = Nicher<MyNiching>)] // <- this time with a `Nicher`
+///     field: Option<Nichable>,
+/// }
+///
+/// #[derive(Archive, Serialize)]
+/// struct NichedNichable {
+///     num: u16, // <- same as above but with `u16` instead of `NonZeroU16`
+///     other: u64,
+/// }
+///
+/// // Now let's niche `Option<Nichable>` into `NichedNichable`
+/// struct MyNiching;
+///
+/// // SAFETY: The only difference between `Archived<Nichable>` and
+/// // `Archived<NichedNichable>` is the `num` field. Every `NonZeroU16` is a
+/// // valid `u16` so the invariant is maintained. Additionally, the following
+/// // implementation of `is_niched` guarantees that `Archived<Nichable>` is
+/// // safely accessible if `is_niched` returns false.
+/// unsafe impl Niching<Nichable> for MyNiching {
+///     type Niched = NichedNichable;
+///
+///     fn niched() -> Self::Niched {
+///         NichedNichable {
+///             num: 0,
+///             other: 123, // irrelevant
+///         }
+///     }
+///
+///     fn is_niched(niched: &Archived<Self::Niched>) -> bool {
+///         niched.num == 0
+///     }
+/// }
 ///
 /// # fn main() -> Result<(), rkyv::rancor::Error> {
-/// assert!(size_of::<ArchivedNiched>() < size_of::<ArchivedBasic>());
+/// // Indeed, we have a smaller archived representation
+/// assert!(
+///     size_of::<ArchivedWithNiching>() < size_of::<ArchivedWithoutNiching>()
+/// );
 ///
-/// let values = [Niched(Some(1)), Niched(Some(42)), Niched(None)];
+/// let values = [
+///     WithNiching {
+///         field: Some(Nichable {
+///             num: unsafe { NonZeroU16::new_unchecked(123) },
+///             other: 789,
+///         }),
+///     },
+///     WithNiching { field: None },
+/// ];
 /// let bytes = rkyv::to_bytes(&values)?;
-/// let archived = rkyv::access::<[ArchivedNiched; 3], _>(&bytes)?;
-/// assert_eq!(archived[0].0.as_ref(), None);
-/// assert_eq!(archived[1].0.as_ref(), Some(&42.into()));
-/// assert_eq!(archived[2].0.as_ref(), None);
+/// let archived = rkyv::access::<[ArchivedWithNiching; 2], _>(&bytes)?;
+/// assert_eq!(archived[0].field.as_ref(), Some(&Archived<789>));
+/// assert!(archived[1].field.is_none());
 /// # Ok(()) }
 /// ```
 ///
 /// [`Nicher`]: crate::with::Nicher
 /// [`is_niched`]: Niching::is_niched
 pub unsafe trait Niching<T> {
-    /// The archived representation of a niched value.
-    type Niched: Portable;
+    /// The niched representation.
+    type Niched: Archive;
+
+    /// The value that serializes and resolves into a niched instance of
+    /// `T::Archived`.
+    fn niched() -> Self::Niched;
 
     /// Whether the given archived value has been niched or not.
-    fn is_niched(niched: &Self::Niched) -> bool;
-
-    /// Creates a `Self::Niched` and writes it to the given output.
-    fn resolve_niched(out: Place<Self::Niched>);
+    fn is_niched(niched: &Archived<Self::Niched>) -> bool;
 }
 
 /// [`Niching`] for zero-niched values.


### PR DESCRIPTION
The current `Niching` trait is lacking utility for any kind of wrapper struct that contains a nichable field, as well as niched types that require a resolver, so I adjusted the trait's definition to extend its functionality.

The documentation for `Niching` includes an updated example.

This is about as much refinement as I could come up with for the trait. The two previous remaining questions about the `CheckBytes` implementation and a `take` implementation for `NichedOption` aren't touched here.

As always, am happy to adjust things with feedback 😃 