### PR TITLE
docs: Fix incorrect URL for Climatiq Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Thanks to all the sponsors that keep development sustainable. Special thanks to 
 ## Bronze Sponsors
 
 <p align="center">
-    <a href="https://climatiq.hq">
+    <a href="https://climatiq.io">
         <img src="https://raw.githubusercontent.com/rkyv/rkyv/master/media/sponsors/climatiq.png" alt="Climatiq">
     </a>
 </p>


### PR DESCRIPTION
I noticed a issue in the "Thanks" section of the README file. The URL for Climatiq was pointing to an incorrect domain (`https://climatiq.hq`). I’ve updated it to the correct one: `https://www.climatiq.io`.

This should ensure the link directs users to the right website. Thanks!