### PR TITLE
Fix typos in documentation

### DIFF
--- a/book_src/architecture/relative-pointers.md
+++ b/book_src/architecture/relative-pointers.md
@@ -3,7 +3,7 @@
 Relative pointers are the bread and butter of total zero-copy deserialization, completely replacing
 the use of normal pointers. But why can't we use normal pointers?
 
-Consider some zero-copy data on disc. Before we can use it, we need to load it into memory. But we
+Consider some zero-copy data on disk. Before we can use it, we need to load it into memory. But we
 can't control _where_ in memory it gets loaded. Every time we load it, it could be located at a
 different address, and therefore the objects inside of it will be located at a different address.
 

--- a/book_src/zero-copy-deserialization.md
+++ b/book_src/zero-copy-deserialization.md
@@ -52,7 +52,7 @@ to the borrowed characters.
 > buffer to find out where everything is.
 
 Partial zero-copy deserialization can considerably improve memory usage and often speed up
-some deserialiation, but with some work we can go further.
+some deserialization, but with some work we can go further.
 
 ## Total zero-copy
 


### PR DESCRIPTION
Fixed spelling errors in documentation files:

book_src/zero-copy-deserialization.md:
- "deserialiation" → "deserialization" (standard technical term spelling)
- "disc" → "disk" (conventional spelling in computing contexts)