### PR TITLE
Add documentation for struct fields

### DIFF
--- a/rkyv_derive/src/archive/struct.rs
+++ b/rkyv_derive/src/archive/struct.rs
@@ -176,11 +176,18 @@ fn generate_archived_type(
             ..
         } = field;
 
+        let field_name = ident.as_ref();
+        let field_doc = format!(
+            "The archived counterpart of [`{}:{}`]",
+            name,
+            field_name.map_or("unnamed".to_string(), |s| s.to_string())
+        );
         let field_attrs = FieldAttributes::parse(attributes, field)?;
         let field_metas = field_attrs.metas();
         let ty = field_attrs.archived(rkyv_path, field);
 
         archived_fields.extend(quote! {
+            #[doc = #field_doc]
             #field_metas
             #vis #ident #colon_token #ty,
         });


### PR DESCRIPTION
Related to #596

## Tests

Run this branch with `cargo expand ArchivedTest -p rkyv --example readme` to find the added documentation.

An automated test with `deny(missing_docs)` would be a great addition but let's discuss first.