### PR TITLE
Avoid type alias in trait impl

### DIFF
--- a/rkyv/src/impls/mod.rs
+++ b/rkyv/src/impls/mod.rs
@@ -630,6 +630,7 @@ mod core_tests {
         #[derive(
             Clone, Debug, Default, Archive, Deserialize, Portable, Serialize,
         )]
+        // Self should be handled specifically (we can't `impl ... for Self`)
         #[rkyv(crate, as = Self)]
         #[repr(C)]
         struct Example {


### PR DESCRIPTION
Following discord's discussion: https://discordapp.com/channels/822925794249539645/1356558336752877679/1357009874730356747

<details><summary>Transcript</summary>
<p>

`taintegral`:

With a macro expansion, it looks like this is caused by the use of type alises in trait impls. This impl triggers the lint:

```rs
impl<
    __D: ::rkyv::rancor::Fallible + ?Sized,
    T,
    const R: usize,
    const C: usize,
> ::rkyv::Deserialize<Matrix<T, R, C>, __D> for ::rkyv::Archived<Matrix<T, R, C>>
```

but this one doesn't
```rs
impl<
    __D: ::rkyv::rancor::Fallible + ?Sized,
    T,
    const R: usize,
    const C: usize,
> ::rkyv::Deserialize<Matrix<T, R, C>, __D> for ArchivedMatrix<T, R, C>
```
(note the exchange of ::rkyv::Archived<Matrix<T, R, C>> for ArchivedMatrix<T, R, C>) 

I thought we got rid of all of the uses of type alises in trait impls, but I guess I imagined that. If you want to do that change, I'd be happy to review/merge.

---


</p>
</details> 

## TL;DR

`Deserialize` macro fails at surprising setups, due to type alias being used.

## Current status

See comments
