### PR TITLE
(experiment) Add support for doc-scrape-examples

### DIFF
--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -66,6 +66,7 @@ uuid-1 = ["dep:uuid-1", "bytecheck?/uuid-1"]
 
 [package.metadata.docs.rs]
 features = ["bytecheck"]
+cargo-args = ["-Z", "unstable-options", "-Z", "rustdoc-scrape-examples", "--no-deps"]
 
 [dev-dependencies]
 ahash = "0.8"
@@ -85,3 +86,36 @@ harness = false
 [[bench]]
 name = "minecraft_savedata"
 harness = false
+
+[[example]]
+name = "backwards_compat"
+doc-scrape-examples = true
+
+[[example]]
+name = "complex_wrapper_types"
+doc-scrape-examples = true
+
+[[example]]
+name = "derive_partial_ord"
+doc-scrape-examples = true
+
+[[example]]
+name = "explicit_enum_discriminants"
+doc-scrape-examples = true
+
+[[example]]
+name = "json_like_schema"
+doc-scrape-examples = true
+
+[[example]]
+name = "niching"
+doc-scrape-examples = true
+
+[[example]]
+name = "readme"
+doc-scrape-examples = true
+
+[[example]]
+name = "remote_types"
+doc-scrape-examples = true
+

--- a/rkyv/examples/niching.rs
+++ b/rkyv/examples/niching.rs
@@ -21,6 +21,7 @@ struct ContainsNiches {
 }
 
 // Here's the same type but without the niches.
+#[expect(unused)]
 #[derive(Archive)]
 struct WithoutNiches {
     non_zero: Option<NonZeroU64>,


### PR DESCRIPTION
- Add cargo-args on package.metadata.docs.rs to add unstable options and rustdoc-scrape-examples
- Explicitly add examples to Cargo.toml
- (unrelated warning fix in niching.rs)