### PR TITLE
Added ArchivedBTreeMap::range and ArchivedBTreeMap::range_seal methods

### DIFF
--- a/rkyv/src/collections/btree/map/iter.rs
+++ b/rkyv/src/collections/btree/map/iter.rs
@@ -382,15 +382,14 @@ impl<K, V, const E: usize> RawRangeIter<K, V, E> {
             return Self { stack: Vec::new(), end_key: None, done: true };
         }
 
-        let mut stack = Vec::new();
-        stack.reserve(entries_to_height::<E>(len) as usize);
+        let mut stack = Vec::with_capacity(entries_to_height::<E>(len) as usize);
 
         unsafe { Self::init_stack_for_lower(map, range, &mut stack) };
 
         let end_key = unsafe { Self::find_first_past_upper(map, range) };
 
         let done = stack.is_empty()
-            || end_key.map_or(false, |ek| {
+            || end_key.is_some_and(|ek| {
                 if let Some((node, idx)) = stack.last() {
                     let k = unsafe { addr_of_mut!((*(*node)).keys[*idx]).cast::<K>() };
                     k == ek

--- a/rkyv/src/collections/btree/map/mod.rs
+++ b/rkyv/src/collections/btree/map/mod.rs
@@ -1097,7 +1097,7 @@ mod tests {
     fn test_range_str() {
         let mut map = BTreeMap::new();
         for i in 'a'..'z' {
-          map.insert(i.to_string(),i.to_string());
+            map.insert(i.to_string(), i.to_string());
         }
 
         to_archived(&map, |archived_map| {
@@ -1125,7 +1125,7 @@ mod tests {
     fn test_range_u32() {
         let mut map = BTreeMap::new();
         for i in 0..200 {
-          map.insert(i as u32,i as u32);
+            map.insert(i as u32, i as u32);
         }
 
         to_archived(&map, |archived_map| {

--- a/rkyv/src/collections/btree/map/mod.rs
+++ b/rkyv/src/collections/btree/map/mod.rs
@@ -1094,7 +1094,7 @@ mod tests {
     }
 
     #[test]
-    fn test_range() {
+    fn test_range_str() {
         let mut map = BTreeMap::new();
         for i in 'a'..'z' {
           map.insert(i.to_string(),i.to_string());
@@ -1102,8 +1102,8 @@ mod tests {
 
         to_archived(&map, |archived_map| {
             let mut hasher = AHasher::default();
-            let start = String::from("d");
-            let end = String::from("w");
+            let start = "d".to_string();
+            let end = "w".to_string();
             for (k, v) in archived_map.range(start.as_str()..end.as_str()) {
                 k.hash(&mut hasher);
                 v.hash(&mut hasher);
@@ -1112,6 +1112,34 @@ mod tests {
 
             let mut expected_hasher = AHasher::default();
             for (k, v) in map.range(start..end) {
+                k.hash(&mut expected_hasher);
+                v.hash(&mut expected_hasher);
+            }
+            let expected_hash_value = expected_hasher.finish();
+
+            assert_eq!(hash_value, expected_hash_value);
+        });
+    }
+
+    #[test]
+    fn test_range_u32() {
+        let mut map = BTreeMap::new();
+        for i in 0..200 {
+          map.insert(i as u32,i as u32);
+        }
+
+        to_archived(&map, |archived_map| {
+            let mut hasher = AHasher::default();
+            let start: rend::u32_le = 32.into();
+            let end: rend::u32_le = 100.into();
+            for (k, v) in archived_map.range(&start..&end) {
+                k.hash(&mut hasher);
+                v.hash(&mut hasher);
+            }
+            let hash_value = hasher.finish();
+
+            let mut expected_hasher = AHasher::default();
+            for (k, v) in map.range(32..100) {
                 k.hash(&mut expected_hasher);
                 v.hash(&mut expected_hasher);
             }

--- a/rkyv/src/collections/btree/map/mod.rs
+++ b/rkyv/src/collections/btree/map/mod.rs
@@ -1092,4 +1092,32 @@ mod tests {
             assert_eq!(hash_value, expected_hash_value);
         });
     }
+
+    #[test]
+    fn test_range() {
+        let mut map = BTreeMap::new();
+        for i in 'a'..'z' {
+          map.insert(i.to_string(),i.to_string());
+        }
+
+        to_archived(&map, |archived_map| {
+            let mut hasher = AHasher::default();
+            let start = String::from("d");
+            let end = String::from("w");
+            for (k, v) in archived_map.range(start.as_str()..end.as_str()) {
+                k.hash(&mut hasher);
+                v.hash(&mut hasher);
+            }
+            let hash_value = hasher.finish();
+
+            let mut expected_hasher = AHasher::default();
+            for (k, v) in map.range(start..end) {
+                k.hash(&mut expected_hasher);
+                v.hash(&mut expected_hasher);
+            }
+            let expected_hash_value = expected_hasher.finish();
+
+            assert_eq!(hash_value, expected_hash_value);
+        });
+    }
 }


### PR DESCRIPTION
Added
- ArchivedBTreeMap::range
- ArchivedBTreeMap::range_seal


Provides a similar interface to std BTreeMap.