### PR TITLE
Relax access sanity check

### DIFF
--- a/rkyv/src/api/mod.rs
+++ b/rkyv/src/api/mod.rs
@@ -50,7 +50,7 @@ fn sanity_check_buffer<T: Portable>(ptr: *const u8, pos: usize, size: usize) {
         root_size,
     );
     let expect_align = align_of::<T>();
-    let actual_align = (ptr as usize) & (expect_align - 1);
+    let actual_align = (ptr as usize).wrapping_add(pos) & (expect_align - 1);
     debug_assert_eq!(
         actual_align,
         0,


### PR DESCRIPTION

The `sanity_check_buffer` function currently checks that the start of the buffer is aligned to `align_of::<ArchivedType>()`.
There are however situations where this is not the case for a valid record. e.g.:

A slice at `0x10001` of length `19` can fit a `ArchivedVec<u8>` of length 3 like this:
`[D, D, D, P, P, P, P, L, L, L, L]` (D=data, P=relptr, L=length)

where
```rs
start = 0x10001
len = 19
root_pos = start + len - size_of::<ArchivedVec<u8>>() = 0x10001 + 3 =  0x10004
root_pos % 4 == 0 => ArchivedVec<u8> is properly aligned 
```

The current `sanity_check_buffer` checks the start of the buffer, so `start % 4 == 0x10001 % 4 == 0` which fails.

By checking if the `root_position` is properly aligned for its type instead of the start of the buffer, the `sanity_check` should still work properly to guard against people passing an unaligned `Vec` without being overly restrictive.


