### PR TITLE
Provide alignment of bytes written to `Writer`.

### DIFF
--- a/rkyv/src/collections/btree/map/mod.rs
+++ b/rkyv/src/collections/btree/map/mod.rs
@@ -575,7 +575,7 @@ impl<K, V, const E: usize> ArchivedBTreeMap<K, V, E> {
                 size_of::<LeafNode<K, V, E>>(),
             )
         };
-        serializer.write(bytes)?;
+        serializer.write(align_of::<LeafNode<K, V, E>>(), bytes)?;
 
         Ok(pos)
     }
@@ -654,7 +654,7 @@ impl<K, V, const E: usize> ArchivedBTreeMap<K, V, E> {
                 size_of::<InnerNode<K, V, E>>(),
             )
         };
-        serializer.write(bytes)?;
+        serializer.write(align_of::<InnerNode<K, V, E>>(), bytes)?;
 
         Ok(pos)
     }

--- a/rkyv/src/collections/swiss_table/table.rs
+++ b/rkyv/src/collections/swiss_table/table.rs
@@ -467,12 +467,12 @@ impl<T> ArchivedHashTable<T> {
                                             )?;
                                         }
                                     } else {
-                                        serializer.write(zeros)?;
+                                        serializer.write(align_of::<T>(), zeros)?;
                                     }
                                 }
 
                                 let pos = serializer.pos();
-                                serializer.write(control_bytes)?;
+                                serializer.write(1, control_bytes)?;
 
                                 Ok(HashTableResolver {
                                     pos: pos as FixedUsize,

--- a/rkyv/src/impls/core/ffi.rs
+++ b/rkyv/src/impls/core/ffi.rs
@@ -53,7 +53,7 @@ impl ArchivePointee for CStr {
 impl<S: Fallible + Writer + ?Sized> SerializeUnsized<S> for CStr {
     fn serialize_unsized(&self, serializer: &mut S) -> Result<usize, S::Error> {
         let result = serializer.pos();
-        serializer.write(self.to_bytes_with_nul())?;
+        serializer.write(1, self.to_bytes_with_nul())?;
         Ok(result)
     }
 }

--- a/rkyv/src/impls/core/mod.rs
+++ b/rkyv/src/impls/core/mod.rs
@@ -294,7 +294,7 @@ where
                     core::mem::size_of_val(self),
                 )
             };
-            serializer.write(as_bytes)?;
+            serializer.write(core::mem::align_of::<T::Archived>(), as_bytes)?;
 
             Ok(result)
         } else {
@@ -390,7 +390,7 @@ impl ArchivePointee for str {
 impl<S: Fallible + Writer + ?Sized> SerializeUnsized<S> for str {
     fn serialize_unsized(&self, serializer: &mut S) -> Result<usize, S::Error> {
         let result = serializer.pos();
-        serializer.write(self.as_bytes())?;
+        serializer.write(1, self.as_bytes())?;
         Ok(result)
     }
 }

--- a/rkyv/src/rc.rs
+++ b/rkyv/src/rc.rs
@@ -101,7 +101,7 @@ impl<T: ArchivePointee + ?Sized, F> ArchivedRc<T, F> {
         // write any data by serializing `value`, pad the serializer by a byte
         // to ensure that our position will be unique.
         if serializer.pos() == pos {
-            serializer.write(&[0])?;
+            serializer.write_padding(1)?;
         }
 
         Ok(RcResolver {

--- a/rkyv/src/rc.rs
+++ b/rkyv/src/rc.rs
@@ -8,7 +8,7 @@ use rancor::{Fallible, Source};
 use crate::{
     primitive::FixedUsize,
     seal::Seal,
-    ser::{Sharing, SharingExt, Writer, WriterExt as _},
+    ser::{Sharing, SharingExt, Writer},
     traits::ArchivePointee,
     ArchiveUnsized, Place, Portable, RelPtr, SerializeUnsized,
 };
@@ -101,7 +101,7 @@ impl<T: ArchivePointee + ?Sized, F> ArchivedRc<T, F> {
         // write any data by serializing `value`, pad the serializer by a byte
         // to ensure that our position will be unique.
         if serializer.pos() == pos {
-            serializer.pad(1)?;
+            serializer.write(&[0])?;
         }
 
         Ok(RcResolver {

--- a/rkyv/src/ser/mod.rs
+++ b/rkyv/src/ser/mod.rs
@@ -57,6 +57,10 @@ impl<W: Writer<E>, A, S, E> Writer<E> for Serializer<W, A, S> {
     fn write(&mut self, bytes: &[u8]) -> Result<(), E> {
         self.writer.write(bytes)
     }
+
+    fn align(&mut self, align: usize) -> Result<usize, E> {
+        self.writer.align(align)
+    }
 }
 
 unsafe impl<W, A: Allocator<E>, S, E> Allocator<E> for Serializer<W, A, S> {

--- a/rkyv/src/ser/mod.rs
+++ b/rkyv/src/ser/mod.rs
@@ -54,12 +54,12 @@ impl<W: Positional, A, S> Positional for Serializer<W, A, S> {
 }
 
 impl<W: Writer<E>, A, S, E> Writer<E> for Serializer<W, A, S> {
-    fn write(&mut self, bytes: &[u8]) -> Result<(), E> {
-        self.writer.write(bytes)
+    fn write(&mut self, align: usize, bytes: &[u8]) -> Result<(), E> {
+        self.writer.write(align, bytes)
     }
 
-    fn align(&mut self, align: usize) -> Result<usize, E> {
-        self.writer.align(align)
+    fn write_padding(&mut self, padding: usize) -> Result<(), E> {
+        self.writer.write_padding(padding)
     }
 }
 

--- a/rkyv/src/ser/writer/alloc.rs
+++ b/rkyv/src/ser/writer/alloc.rs
@@ -12,8 +12,13 @@ impl Positional for Vec<u8> {
 }
 
 impl<E> Writer<E> for Vec<u8> {
-    fn write(&mut self, bytes: &[u8]) -> Result<(), E> {
+    fn write(&mut self, _align: usize, bytes: &[u8]) -> Result<(), E> {
         self.extend_from_slice(bytes);
+        Ok(())
+    }
+
+    fn write_padding(&mut self, n: usize) -> Result<(), E> {
+        self.resize(self.len() + n, 0);
         Ok(())
     }
 }
@@ -26,8 +31,13 @@ impl<const A: usize> Positional for AlignedVec<A> {
 }
 
 impl<E, const A: usize> Writer<E> for AlignedVec<A> {
-    fn write(&mut self, bytes: &[u8]) -> Result<(), E> {
+    fn write(&mut self, _align: usize, bytes: &[u8]) -> Result<(), E> {
         self.extend_from_slice(bytes);
+        Ok(())
+    }
+
+    fn write_padding(&mut self, n: usize) -> Result<(), E> {
+        self.resize(self.len() + n, 0);
         Ok(())
     }
 }

--- a/rkyv/src/ser/writer/core.rs
+++ b/rkyv/src/ser/writer/core.rs
@@ -4,7 +4,7 @@ use core::{
     marker::PhantomData,
     mem::MaybeUninit,
     ops::{Deref, DerefMut},
-    ptr::{copy_nonoverlapping, NonNull},
+    ptr::{copy_nonoverlapping, write_bytes, NonNull},
     slice,
 };
 
@@ -145,7 +145,7 @@ impl Positional for Buffer<'_> {
 }
 
 impl<E: Source> Writer<E> for Buffer<'_> {
-    fn write(&mut self, bytes: &[u8]) -> Result<(), E> {
+    fn write(&mut self, _align: usize, bytes: &[u8]) -> Result<(), E> {
         if bytes.len() > self.cap - self.len {
             fail!(BufferOverflow {
                 write_len: bytes.len(),
@@ -161,6 +161,23 @@ impl<E: Source> Writer<E> for Buffer<'_> {
                 );
             }
             self.len += bytes.len();
+            Ok(())
+        }
+    }
+
+    fn write_padding(&mut self, n: usize) -> Result<(), E> {
+        if n > self.cap - self.len {
+            fail!(BufferOverflow {
+                write_len: n,
+                cap: self.cap,
+                len: self.len,
+            });
+        } else {
+            unsafe {
+                let dst = self.ptr.as_ptr().add(self.len);
+                write_bytes(dst, 0, n);
+            }
+            self.len += n;
             Ok(())
         }
     }

--- a/rkyv/src/ser/writer/std.rs
+++ b/rkyv/src/ser/writer/std.rs
@@ -54,7 +54,7 @@ impl<W> Positional for IoWriter<W> {
 }
 
 impl<W: io::Write, E: Source> Writer<E> for IoWriter<W> {
-    fn write(&mut self, bytes: &[u8]) -> Result<(), E> {
+    fn write(&mut self, _align: usize, bytes: &[u8]) -> Result<(), E> {
         self.inner.write_all(bytes).into_error()?;
         self.pos += bytes.len();
         Ok(())


### PR DESCRIPTION
Hi!

When serializing rkyv data it seems there is no reliable way to know the required alignment of serialized bytes. As I understand currently it works by assuming that alignment 16 is enough for practical cases. This can be both not enough, and too much.

In my case, I actually pack many independent rkyved bytes together, in a single buffer, so I want to know the minimal required alignment, which can be <16 in many cases, to save space on unneeded padding. That is why I want to know the exact requirement, not large enough assumption.

I added `align` parameter to `Writer::write` method, so for each write the intended alignment of written value is communicated, and custom implementation of `Writer` can use it.

Also I added `write_padding` method directly to `Writer` trait, so it can be overwritten with more efficient implementation.

I am marking it as "draft" PR to discuss this issue and possible solution.