### PR TITLE
Clicking "Go To Definition" on `ArchivedType` will now go to `Type` instead of `fn derive_archive`

### DIFF
--- a/rkyv_derive/src/archive/printing.rs
+++ b/rkyv_derive/src/archive/printing.rs
@@ -29,10 +29,16 @@ impl Printing {
             .unwrap_or_else(|| parse_quote! { ::rkyv });
 
         let base_name = strip_raw(&name);
-        let archived_name = attributes
+        let mut archived_name = attributes
             .archived
             .clone()
             .unwrap_or_else(|| format_ident!("Archived{}", base_name));
+
+        // This makes it so when you do "goto definition" on an `ArchivedType`,
+        // it will go to the definition of `Type` instead of going to definition
+        // of the `Archived` derive proc macro
+        archived_name.set_span(name.span());
+
         let archived_type = attributes
             .as_type
             .clone()


### PR DESCRIPTION
When you have an `ArchivedType`, and you do "go to definition" you will be taken to 2 places:
- Definition of the derive macro itself
- The `#[derive]` attribute itself that applies `Archived` proc macro

You usually don't want to do either of those, and would much rather go to the actual definition of the `Type` instead. It's as if you had clicked "go to definition"on `Type` instead of `ArchivedType`

this is what this PR does.