### PR TITLE
Fix new warning preventing running `cargo test`

### DIFF
--- a/rkyv/src/string/repr.rs
+++ b/rkyv/src/string/repr.rs
@@ -202,14 +202,11 @@ impl ArchivedStringRepr {
         target: usize,
         out: Place<Self>,
     ) -> Result<(), E> {
-        let (len, offset) = unsafe {
-            munge! {
-                let ArchivedStringRepr {
-                    out_of_line: OutOfLineRepr { len, offset, _phantom: _ }
-                } = out;
-            }
-            (len, offset)
-        };
+        munge! {
+            let ArchivedStringRepr {
+                out_of_line: OutOfLineRepr { len, offset, _phantom: _ }
+            } = out;
+        }
 
         let l = value.len() as FixedUsize;
         // Little-endian: insert 10 as the 7th and 8th bits


### PR DESCRIPTION
The warning was:
<img width="601" height="230" alt="image" src="https://github.com/user-attachments/assets/cf53b0ca-716a-41e3-8331-2d5cfc4b1f10" />


Because of the strong use of deny, `cargo test` or `cargo build` on this repo will fail.
This PR fixes the issue.

IMO, denying warnings in CI is great, BUT you really need to pin the rust version if you are going to do that.