### PR TITLE
Avoid ambiguous associated item references

### DIFF
--- a/rkyv_derive/src/archive/enum.rs
+++ b/rkyv_derive/src/archive/enum.rs
@@ -151,7 +151,8 @@ pub fn impl_enum(
                 fn resolve(
                     &self,
                     resolver: <Self as #rkyv_path::Archive>::Resolver,
-                    out: #rkyv_path::Place<<Self as #rkyv_path::Archive>::Archived>,
+                    out: #rkyv_path::Place<
+                        <Self as #rkyv_path::Archive>::Archived>,
                 ) {
                     let __this = self;
                     match resolver {


### PR DESCRIPTION
Hello rkyv folks!

I noticed this while trying to derive `rkyv::Archive` on an enum that contains an `Archived` variant:

```rust
#[derive(
    Clone, Copy, Debug, Default, Eq, PartialEq, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
)]
#[rkyv(derive(Debug))]
pub enum Status {
    #[default]
    Active,
    Archived,
    Quarantined,
    Deprecated,
}
```

yields the following error:

```
error: ambiguous associated item
   --> crates/uv-pypi-types/src/project_status.rs:14:49
    |
 14 |     Clone, Copy, Debug, Default, Eq, PartialEq, rkyv::Archive, rkyv::Deseriali...
    |                                                 ^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57644 <https://github.com/rust-lang/rust/issues/57644>
note: `Archived` could refer to the variant defined here
   --> crates/uv-pypi-types/src/project_status.rs:20:5
    |
 20 |     Archived,
    |     ^^^^^^^^
note: `Archived` could also refer to the associated type defined here
   --> /Users/william/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rkyv-0.8.12/src/traits.rs:229:5
    |
229 |     type Archived: Portable;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    = note: `#[deny(ambiguous_associated_items)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the derive macro `rkyv::Archive` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `uv-pypi-types` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

This is happening because `Archive` (the trait) has an associated type `Archived`, so `Self::Archive` ambiguously refers to either `Archive::Archived` _or_ to `ProjectStatus::Archived`.

The solution to this is for the first-party to disambiguate its access. In this case that's as simple as `<Self as Archive>::Archived`. This PR contains that change, plus its equivalent in the derive APIs.

Note: I haven't attempted to suss out other ambiguous associated items, this is only one I happened to hit! So there are potentially others lurking.

Rust tracker: https://github.com/rust-lang/rust/issues/57644