### PR TITLE
Remove unnecesssary bounds

### DIFF
--- a/rkyv/src/impls/alloc/collections/btree_map.rs
+++ b/rkyv/src/impls/alloc/collections/btree_map.rs
@@ -9,10 +9,7 @@ use crate::{
     Archive, Deserialize, Place, Serialize,
 };
 
-impl<K: Archive + Ord, V: Archive> Archive for BTreeMap<K, V>
-where
-    K::Archived: Ord,
-{
+impl<K: Archive + Ord, V: Archive> Archive for BTreeMap<K, V> {
     type Archived = ArchivedBTreeMap<K::Archived, V::Archived>;
     type Resolver = BTreeMapResolver;
 
@@ -24,7 +21,6 @@ where
 impl<K, V, S> Serialize<S> for BTreeMap<K, V>
 where
     K: Serialize<S> + Ord,
-    K::Archived: Ord,
     V: Serialize<S>,
     S: Allocator + Fallible + Writer + ?Sized,
     S::Error: Source,
@@ -44,7 +40,7 @@ impl<K, V, D> Deserialize<BTreeMap<K, V>, D>
     for ArchivedBTreeMap<K::Archived, V::Archived>
 where
     K: Archive + Ord,
-    K::Archived: Deserialize<K, D> + Ord,
+    K::Archived: Deserialize<K, D>,
     V: Archive,
     V::Archived: Deserialize<V, D>,
     D: Fallible + ?Sized,

--- a/rkyv/src/impls/alloc/collections/btree_set.rs
+++ b/rkyv/src/impls/alloc/collections/btree_set.rs
@@ -9,10 +9,7 @@ use crate::{
     Archive, Deserialize, Place, Serialize,
 };
 
-impl<K: Archive + Ord> Archive for BTreeSet<K>
-where
-    K::Archived: Ord,
-{
+impl<K: Archive + Ord> Archive for BTreeSet<K> {
     type Archived = ArchivedBTreeSet<K::Archived>;
     type Resolver = BTreeSetResolver;
 
@@ -28,7 +25,6 @@ where
 impl<K, S> Serialize<S> for BTreeSet<K>
 where
     K: Serialize<S> + Ord,
-    K::Archived: Ord,
     S: Fallible + Allocator + Writer + ?Sized,
     S::Error: Source,
 {
@@ -46,7 +42,7 @@ where
 impl<K, D> Deserialize<BTreeSet<K>, D> for ArchivedBTreeSet<K::Archived>
 where
     K: Archive + Ord,
-    K::Archived: Deserialize<K, D> + Ord,
+    K::Archived: Deserialize<K, D>,
     D: Fallible + ?Sized,
 {
     fn deserialize(

--- a/rkyv/src/impls/ext/hashbrown.rs
+++ b/rkyv/src/impls/ext/hashbrown.rs
@@ -20,7 +20,6 @@ macro_rules! impl_hashbrown {
             impl<K, V: Archive, S> Archive for HashMap<K, V, S>
             where
                 K: Archive + Hash + Eq,
-                K::Archived: Hash + Eq,
             {
                 type Archived = ArchivedHashMap<K::Archived, V::Archived>;
                 type Resolver = HashMapResolver;

--- a/rkyv/src/impls/std/collections/hash_map.rs
+++ b/rkyv/src/impls/std/collections/hash_map.rs
@@ -15,7 +15,6 @@ use crate::{
 impl<K, V: Archive, S> Archive for HashMap<K, V, S>
 where
     K: Archive + Hash + Eq,
-    K::Archived: Hash + Eq,
 {
     type Archived = ArchivedHashMap<K::Archived, V::Archived>;
     type Resolver = HashMapResolver;
@@ -28,7 +27,6 @@ where
 impl<K, V, S, RandomState> Serialize<S> for HashMap<K, V, RandomState>
 where
     K: Serialize<S> + Hash + Eq,
-    K::Archived: Hash + Eq,
     V: Serialize<S>,
     S: Fallible + Writer + Allocator + ?Sized,
     S::Error: Source,
@@ -52,7 +50,7 @@ impl<K, V, D, S> Deserialize<HashMap<K, V, S>, D>
     for ArchivedHashMap<K::Archived, V::Archived>
 where
     K: Archive + Hash + Eq,
-    K::Archived: Deserialize<K, D> + Hash + Eq,
+    K::Archived: Deserialize<K, D>,
     V: Archive,
     V::Archived: Deserialize<V, D>,
     D: Fallible + ?Sized,

--- a/rkyv/src/impls/std/collections/hash_set.rs
+++ b/rkyv/src/impls/std/collections/hash_set.rs
@@ -15,7 +15,6 @@ use crate::{
 impl<K, S> Archive for HashSet<K, S>
 where
     K: Archive + Hash + Eq,
-    K::Archived: Hash + Eq,
 {
     type Archived = ArchivedHashSet<K::Archived>;
     type Resolver = HashSetResolver;
@@ -32,7 +31,6 @@ where
 
 impl<K, S, RS> Serialize<S> for HashSet<K, RS>
 where
-    K::Archived: Hash + Eq,
     K: Serialize<S> + Hash + Eq,
     S: Fallible + Allocator + Writer + ?Sized,
     S::Error: Source,
@@ -52,7 +50,7 @@ where
 impl<K, D, S> Deserialize<HashSet<K, S>, D> for ArchivedHashSet<K::Archived>
 where
     K: Archive + Hash + Eq,
-    K::Archived: Deserialize<K, D> + Hash + Eq,
+    K::Archived: Deserialize<K, D>,
     D: Fallible + ?Sized,
     S: Default + BuildHasher,
 {


### PR DESCRIPTION
Removing these bounds saved me >300 lines in my project. Types that do not implement the bounds will be of limited usefulness when archived, but if you don't use the archived versions of the types except to deserialize them it's nice not to have to specify the bounds.