### PR TITLE
Add `#[repr(C)]` for `AlignedVec`

### DIFF
--- a/rkyv/src/util/alloc/aligned_vec.rs
+++ b/rkyv/src/util/alloc/aligned_vec.rs
@@ -28,6 +28,7 @@ use crate::{
 /// let bytes = AlignedVec::<4096>::with_capacity(1);
 /// assert_eq!(bytes.as_ptr() as usize % 4096, 0);
 /// ```
+#[repr(C)]
 pub struct AlignedVec<const ALIGNMENT: usize = 16> {
     ptr: NonNull<u8>,
     cap: usize,


### PR DESCRIPTION
When going Rust to Rust via the C ABI, we need FFI safe types. `AlignedVec`'s fields are already perfectly suitable for an FFI boundary, so adding `#[repr(C)]` is the only change necessary to allow that to happen safely (if you can ever call FFI safe ...).