### PR TITLE
Update to hashbrown 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/rkyv/rkyv"
 [workspace.dependencies]
 bytecheck = { version = "0.8", default-features = false, features = ["simdutf8"] }
 divan = { version = "0.1", default-features = false }
-hashbrown = { version = "0.16", default-features = false }
+hashbrown = { version = "0.17", default-features = false }
 munge = { version = "0.4", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 ptr_meta = { version = "0.3", default-features = false }

--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -35,8 +35,9 @@ arrayvec-0_7 = { package = "arrayvec", version = "0.7", optional = true, default
 bytes-1 = { package = "bytes", version = "1", optional = true, default-features = false }
 hashbrown-0_14 = { package = "hashbrown", version = "0.14", optional = true, default-features = false }
 hashbrown-0_15 = { package = "hashbrown", version = "0.15", optional = true, default-features = false }
-# rkyv already depends on hashbrown 0.16, so we can't duplicate this, but we can expose it as a feature below
-# hashbrown-0_16 = { package = "hashbrown", version = "0.16", optional = true, default-features = false }
+hashbrown-0_16 = { package = "hashbrown", version = "0.16", optional = true, default-features = false }
+# rkyv already depends on hashbrown 0.17, so we can't duplicate this, but we can expose it as a feature below
+# hashbrown-0_17 = { package = "hashbrown", version = "0.17", optional = true, default-features = false }
 indexmap-2 = { package = "indexmap", version = "2", optional = true, default-features = false }
 smallvec-1 = { package = "smallvec", version = "1", optional = true, default-features = false }
 smol_str-0_2 = { package = "smol_str", version = "0.2", optional = true, default-features = false }
@@ -60,7 +61,7 @@ std = ["alloc", "bytes-1?/std", "indexmap-2?/std", "ptr_meta/std", "uuid-1?/std"
 bytecheck = ["dep:bytecheck", "rend/bytecheck", "rkyv_derive/bytecheck"]
 
 # External crate support
-hashbrown-0_16 = ["dep:hashbrown"]
+hashbrown-0_17 = ["dep:hashbrown"]
 indexmap-2 = ["dep:indexmap-2", "alloc"]
 triomphe-0_1 = ["dep:triomphe-0_1", "alloc"]
 uuid-1 = ["dep:uuid-1", "bytecheck?/uuid-1"]

--- a/rkyv/src/impls/ext/hashbrown.rs
+++ b/rkyv/src/impls/ext/hashbrown.rs
@@ -441,3 +441,8 @@ mod hashbrown_0_15 {
 mod hashbrown_0_16 {
     impl_hashbrown!(hashbrown);
 }
+
+#[cfg(feature = "hashbrown-0_17")]
+mod hashbrown_0_17 {
+    impl_hashbrown!(hashbrown);
+}

--- a/rkyv/src/impls/ext/mod.rs
+++ b/rkyv/src/impls/ext/mod.rs
@@ -13,7 +13,8 @@ mod bytes_1;
 #[cfg(any(
     feature = "hashbrown-0_14",
     feature = "hashbrown-0_15",
-    feature = "hashbrown-0_16"
+    feature = "hashbrown-0_16",
+    feature = "hashbrown-0_17"
 ))]
 mod hashbrown;
 #[cfg(feature = "indexmap-2")]

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -146,6 +146,8 @@
 //! - [`bytes-1`](https://docs.rs/bytes/1)
 //! - [`hashbrown-0_14`](https://docs.rs/hashbrown/0.14)
 //! - [`hashbrown-0_15`](https://docs.rs/hashbrown/0.15)
+//! - [`hashbrown-0_16`](https://docs.rs/hashbrown/0.16)
+//! - [`hashbrown-0_17`](https://docs.rs/hashbrown/0.17)
 //! - [`indexmap-2`](https://docs.rs/indexmap/2)
 //! - [`smallvec-1`](https://docs.rs/smallvec/1)
 //! - [`smol_str-0_2`](https://docs.rs/smol_str/0.2)


### PR DESCRIPTION
Release notes: https://github.com/rust-lang/hashbrown/releases/tag/v0.17.0