### PR TITLE
Link to the examples directory, instead of away from examples

### DIFF
--- a/book_src/rkyv.md
+++ b/book_src/rkyv.md
@@ -17,6 +17,7 @@ afraid to consult these other resources as you need while you read through.
   issues and meet other people using rkyv
 - The [rkyv github](https://github.com/rkyv/rkyv) hosts the source and tracks project issues
   and milestones.
+- There are examples of usage in [the repository](https://github.com/rkyv/rkyv/tree/main/rkyv/examples).
 
 ## Documentation
 

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -25,10 +25,10 @@
 //! rkyv's types will have exactly the same performance as native types.
 //!
 //! See the [rkyv book] for guide-level documentation.
-//! See [the examples directory] for usage examples.
+//! See [the examples directory][1] for usage examples.
 //!
 //! [rkyv book]: https://rkyv.org
-//! [the examples directory]: https://github.com/rkyv/rkyv/tree/main/rkyv/examples
+//! [1]: https://github.com/rkyv/rkyv/tree/main/rkyv/examples
 //!
 //! ## Components
 //!

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -28,7 +28,7 @@
 //! See [the examples directory] for usage examples.
 //!
 //! [rkyv book]: https://rkyv.org
-//! [the source]: https://github.com/rkyv/rkyv/tree/main/rkyv/examples
+//! [the examples directory]: https://github.com/rkyv/rkyv/tree/main/rkyv/examples
 //!
 //! ## Components
 //!

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -24,9 +24,11 @@
 //! zero-copy types are designed to have little to no overhead. In most cases,
 //! rkyv's types will have exactly the same performance as native types.
 //!
-//! See the [rkyv book] for guide-level documentation and usage examples.
+//! See the [rkyv book] for guide-level documentation.
+//! See [the examples directory] for usage examples.
 //!
 //! [rkyv book]: https://rkyv.org
+//! [the source]: https://github.com/rkyv/rkyv/tree/main/rkyv/examples
 //!
 //! ## Components
 //!


### PR DESCRIPTION
When trying to figure out how to use rkyv, I got stuck in a loop.

https://rkyv.org/ says the book "is the best way to learn and understand rkyv, but won’t go as in-depth on specifics as the documentation will." While the book had a lot of explanation of how rkyv works under the hood, I did not find any full examples of "here is how to archive end-to-end".

https://docs.rs/rkyv/latest/rkyv/ does not contain any examples at the top level either, nor links to any. It says "See the rkyv book for guide-level documentation and usage examples."

Fix this: point to where the examples actually are, in the source tree.
