### PR TITLE
Fix Rc deserialization soundness issue

### DIFF
--- a/rkyv/src/rc.rs
+++ b/rkyv/src/rc.rs
@@ -352,14 +352,15 @@ mod verify {
         fn verify(&self, context: &mut C) -> Result<(), C::Error> {
             let ptr = self.ptr.as_ptr_wrapping();
             let type_id = TypeId::of::<ArchivedRc<T, F>>();
+            let metadata = self.ptr.metadata();
 
             let addr = ptr as *const u8 as usize;
-            match context.start_shared(addr, type_id)? {
+            match context.start_shared(addr, type_id, metadata)? {
                 ValidationState::Started => {
                     context.in_subtree(ptr, |context| unsafe {
                         T::check_bytes(ptr, context)
                     })?;
-                    context.finish_shared(addr, type_id)?;
+                    context.finish_shared(addr, type_id, metadata)?;
                 }
                 ValidationState::Pending => {
                     if !F::ALLOW_CYCLES {
@@ -397,29 +398,22 @@ mod verify {
     }
 }
 
-#[cfg(all(test, miri, feature = "alloc", feature = "bytecheck"))]
+#[cfg(all(test, feature = "alloc", feature = "bytecheck"))]
 mod tests {
     use crate::{
         access,
         alloc::{rc::Rc, vec},
-        to_bytes, Archive, Serialize,
+        from_bytes, to_bytes, Archive, Deserialize, Serialize,
     };
 
-    #[test]
-    fn shared_unsized_metadata_can_change_after_first_validation() {
-        #[derive(Archive, Serialize)]
-        #[rkyv(crate)]
-        struct Test {
-            good: Rc<[u32]>,
-            bad: Rc<[u32]>,
-        }
+    #[derive(Archive, Deserialize, Serialize)]
+    #[rkyv(crate)]
+    struct Test {
+        good: Rc<[u32]>,
+        bad: Rc<[u32]>,
+    }
 
-        // Shared pointer validation keys already-validated pointees by data
-        // address and type only. For unsized pointees, metadata is part of the
-        // pointer validity invariant too. After `good` validates the shared
-        // slice with length 1, `bad` can reuse the same data address with a
-        // forged length and skip validating the larger slice. Safe indexing
-        // then trusts the forged metadata and reads outside the allocation.
+    fn mismatched_shared_metadata_bytes() -> crate::util::AlignedVec {
         let shared = Rc::<[u32]>::from(vec![123].into_boxed_slice());
         let value = Test {
             good: shared.clone(),
@@ -439,7 +433,20 @@ mod tests {
             [bad_metadata_offset..bad_metadata_offset + forged_len_bytes.len()]
             .copy_from_slice(&forged_len_bytes);
 
-        let archived = access::<ArchivedTest, rancor::Error>(&bytes).unwrap();
-        let _ = archived.bad[100].to_native();
+        bytes
+    }
+
+    #[test]
+    fn shared_unsized_metadata_can_change_after_first_validation() {
+        let bytes = mismatched_shared_metadata_bytes();
+
+        assert!(access::<ArchivedTest, rancor::Error>(&bytes).is_err());
+    }
+
+    #[test]
+    fn shared_unsized_metadata_rejected_by_checked_deserialization() {
+        let bytes = mismatched_shared_metadata_bytes();
+
+        assert!(from_bytes::<Test, rancor::Error>(&bytes).is_err());
     }
 }

--- a/rkyv/src/rc.rs
+++ b/rkyv/src/rc.rs
@@ -396,3 +396,50 @@ mod verify {
         }
     }
 }
+
+#[cfg(all(test, miri, feature = "alloc", feature = "bytecheck"))]
+mod tests {
+    use crate::{
+        access,
+        alloc::{rc::Rc, vec},
+        to_bytes, Archive, Serialize,
+    };
+
+    #[test]
+    fn shared_unsized_metadata_can_change_after_first_validation() {
+        #[derive(Archive, Serialize)]
+        #[rkyv(crate)]
+        struct Test {
+            good: Rc<[u32]>,
+            bad: Rc<[u32]>,
+        }
+
+        // Shared pointer validation keys already-validated pointees by data
+        // address and type only. For unsized pointees, metadata is part of the
+        // pointer validity invariant too. After `good` validates the shared
+        // slice with length 1, `bad` can reuse the same data address with a
+        // forged length and skip validating the larger slice. Safe indexing
+        // then trusts the forged metadata and reads outside the allocation.
+        let shared = Rc::<[u32]>::from(vec![123].into_boxed_slice());
+        let value = Test {
+            good: shared.clone(),
+            bad: shared,
+        };
+        let mut bytes = to_bytes::<rancor::Error>(&value).unwrap();
+
+        let bad_metadata_offset = {
+            let archived =
+                access::<ArchivedTest, rancor::Error>(&bytes).unwrap();
+            let metadata = archived.bad.ptr.metadata();
+            metadata as *const _ as usize - bytes.as_ptr() as usize
+        };
+
+        let forged_len_bytes = to_bytes::<rancor::Error>(&1024usize).unwrap();
+        bytes
+            [bad_metadata_offset..bad_metadata_offset + forged_len_bytes.len()]
+            .copy_from_slice(&forged_len_bytes);
+
+        let archived = access::<ArchivedTest, rancor::Error>(&bytes).unwrap();
+        let _ = archived.bad[100].to_native();
+    }
+}

--- a/rkyv/src/validation/mod.rs
+++ b/rkyv/src/validation/mod.rs
@@ -9,6 +9,7 @@ pub use self::{
     archive::{ArchiveContext, ArchiveContextExt},
     shared::SharedContext,
 };
+use crate::traits::NoUndef;
 
 /// The default validator.
 #[derive(Debug)]
@@ -61,20 +62,28 @@ impl<A, S, E> SharedContext<E> for Validator<A, S>
 where
     S: SharedContext<E>,
 {
-    fn start_shared(
+    fn start_shared<M>(
         &mut self,
         address: usize,
         type_id: TypeId,
-    ) -> Result<shared::ValidationState, E> {
-        self.shared.start_shared(address, type_id)
+        metadata: &M,
+    ) -> Result<shared::ValidationState, E>
+    where
+        M: NoUndef,
+    {
+        self.shared.start_shared(address, type_id, metadata)
     }
 
-    fn finish_shared(
+    fn finish_shared<M>(
         &mut self,
         address: usize,
         type_id: TypeId,
-    ) -> Result<(), E> {
-        self.shared.finish_shared(address, type_id)
+        metadata: &M,
+    ) -> Result<(), E>
+    where
+        M: NoUndef,
+    {
+        self.shared.finish_shared(address, type_id, metadata)
     }
 }
 

--- a/rkyv/src/validation/shared/mod.rs
+++ b/rkyv/src/validation/shared/mod.rs
@@ -9,6 +9,7 @@ use rancor::{Fallible, Strategy};
 
 #[cfg(feature = "alloc")]
 pub use self::validator::*;
+use crate::traits::NoUndef;
 
 /// The result of starting to validate a shared pointer.
 pub enum ValidationState {
@@ -30,40 +31,56 @@ pub trait SharedContext<E = <Self as Fallible>::Error> {
     /// Starts validating the value associated with the given address.
     ///
     /// Returns an error if the value associated with the given address was
-    /// started with a different type ID.
-    fn start_shared(
+    /// started with a different type ID or pointer metadata.
+    fn start_shared<M>(
         &mut self,
         address: usize,
         type_id: TypeId,
-    ) -> Result<ValidationState, E>;
+        metadata: &M,
+    ) -> Result<ValidationState, E>
+    where
+        M: NoUndef;
 
     /// Finishes validating the value associated with the given address.
     ///
-    /// Returns an error if the given address was not pending.
-    fn finish_shared(
+    /// Returns an error if the given address was not pending, or if the type
+    /// ID or pointer metadata does not match the corresponding `start_shared`
+    /// call.
+    fn finish_shared<M>(
         &mut self,
         address: usize,
         type_id: TypeId,
-    ) -> Result<(), E>;
+        metadata: &M,
+    ) -> Result<(), E>
+    where
+        M: NoUndef;
 }
 
 impl<T, E> SharedContext<E> for Strategy<T, E>
 where
     T: SharedContext<E>,
 {
-    fn start_shared(
+    fn start_shared<M>(
         &mut self,
         address: usize,
         type_id: TypeId,
-    ) -> Result<ValidationState, E> {
-        T::start_shared(self, address, type_id)
+        metadata: &M,
+    ) -> Result<ValidationState, E>
+    where
+        M: NoUndef,
+    {
+        T::start_shared(self, address, type_id, metadata)
     }
 
-    fn finish_shared(
+    fn finish_shared<M>(
         &mut self,
         address: usize,
         type_id: TypeId,
-    ) -> Result<(), E> {
-        T::finish_shared(self, address, type_id)
+        metadata: &M,
+    ) -> Result<(), E>
+    where
+        M: NoUndef,
+    {
+        T::finish_shared(self, address, type_id, metadata)
     }
 }

--- a/rkyv/src/validation/shared/validator.rs
+++ b/rkyv/src/validation/shared/validator.rs
@@ -1,7 +1,7 @@
 //! Validators add validation capabilities by wrapping and extending basic
 //! validators.
 
-use core::{any::TypeId, error::Error, fmt, hash::BuildHasherDefault};
+use core::{any::TypeId, error::Error, fmt, hash::BuildHasherDefault, mem};
 #[cfg(feature = "std")]
 use std::collections::hash_map;
 
@@ -10,18 +10,24 @@ use hashbrown::hash_map;
 use rancor::{fail, Source};
 
 use crate::{
+    alloc::vec::Vec,
     hash::FxHasher64,
+    traits::NoUndef,
     validation::{shared::ValidationState, SharedContext},
 };
+
+#[derive(Debug)]
+struct SharedPointer {
+    type_id: TypeId,
+    metadata: Vec<u8>,
+    finished: bool,
+}
 
 /// A validator that can verify shared pointers.
 #[derive(Debug, Default)]
 pub struct SharedValidator {
-    shared: hash_map::HashMap<
-        usize,
-        (TypeId, bool),
-        BuildHasherDefault<FxHasher64>,
-    >,
+    shared:
+        hash_map::HashMap<usize, SharedPointer, BuildHasherDefault<FxHasher64>>,
 }
 
 impl SharedValidator {
@@ -63,6 +69,21 @@ impl fmt::Display for TypeMismatch {
 impl Error for TypeMismatch {}
 
 #[derive(Debug)]
+struct MetadataMismatch;
+
+impl fmt::Display for MetadataMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "the same memory region has been claimed with different pointer \
+             metadata",
+        )
+    }
+}
+
+impl Error for MetadataMismatch {}
+
+#[derive(Debug)]
 struct NotStarted;
 
 impl fmt::Display for NotStarted {
@@ -84,25 +105,48 @@ impl fmt::Display for AlreadyFinished {
 
 impl Error for AlreadyFinished {}
 
+fn metadata_bytes<M: NoUndef>(metadata: &M) -> &[u8] {
+    // SAFETY: `NoUndef` guarantees that all bytes of the metadata are
+    // initialized. The returned slice is confined to the lifetime of
+    // `metadata`.
+    unsafe {
+        core::slice::from_raw_parts(
+            (metadata as *const M).cast(),
+            mem::size_of::<M>(),
+        )
+    }
+}
+
 impl<E: Source> SharedContext<E> for SharedValidator {
-    fn start_shared(
+    fn start_shared<M>(
         &mut self,
         address: usize,
         type_id: TypeId,
-    ) -> Result<ValidationState, E> {
+        metadata: &M,
+    ) -> Result<ValidationState, E>
+    where
+        M: NoUndef,
+    {
+        let metadata = metadata_bytes(metadata);
         match self.shared.entry(address) {
             hash_map::Entry::Vacant(vacant) => {
-                vacant.insert((type_id, false));
+                vacant.insert(SharedPointer {
+                    type_id,
+                    metadata: metadata.to_vec(),
+                    finished: false,
+                });
                 Ok(ValidationState::Started)
             }
             hash_map::Entry::Occupied(occupied) => {
-                let (previous_type_id, finished) = occupied.get();
-                if previous_type_id != &type_id {
+                let shared = occupied.get();
+                if shared.type_id != type_id {
                     fail!(TypeMismatch {
-                        previous: *previous_type_id,
+                        previous: shared.type_id,
                         current: type_id,
                     })
-                } else if !finished {
+                } else if shared.metadata != metadata {
+                    fail!(MetadataMismatch)
+                } else if !shared.finished {
                     Ok(ValidationState::Pending)
                 } else {
                     Ok(ValidationState::Finished)
@@ -111,24 +155,31 @@ impl<E: Source> SharedContext<E> for SharedValidator {
         }
     }
 
-    fn finish_shared(
+    fn finish_shared<M>(
         &mut self,
         address: usize,
         type_id: TypeId,
-    ) -> Result<(), E> {
+        metadata: &M,
+    ) -> Result<(), E>
+    where
+        M: NoUndef,
+    {
+        let metadata = metadata_bytes(metadata);
         match self.shared.entry(address) {
             hash_map::Entry::Vacant(_) => fail!(NotStarted),
             hash_map::Entry::Occupied(mut occupied) => {
-                let (previous_type_id, finished) = occupied.get_mut();
-                if previous_type_id != &type_id {
+                let shared = occupied.get_mut();
+                if shared.type_id != type_id {
                     fail!(TypeMismatch {
-                        previous: *previous_type_id,
+                        previous: shared.type_id,
                         current: type_id,
                     });
-                } else if *finished {
+                } else if shared.metadata != metadata {
+                    fail!(MetadataMismatch)
+                } else if shared.finished {
                     fail!(AlreadyFinished);
                 } else {
-                    *finished = true;
+                    shared.finished = true;
                     Ok(())
                 }
             }


### PR DESCRIPTION
Fixes #670

The first commit adds the UB PoC from #670, the second commit fixes the UB loophole. The details are in the commit message.

This is authored by GPT-5.5 and human-reviewed. I decided to see if an LLM that detected the issue can also fix it, and apparently it can. Please let me know if this kind of PR is helpful or not.

A wrinkle that LLMs did _not_ point out: `TypeId` is a hash and theoretically can collide. But the values are not attacker-controlled and we only have a handful of types that we generate a TypeId (the smart pointer types like Rc, Arc and Weak plus user-defined extensions) so I don't think it's an issue in practice.