### PR TITLE
Allow unsized types to be used with Align

### DIFF
--- a/rkyv/src/util/mod.rs
+++ b/rkyv/src/util/mod.rs
@@ -16,12 +16,12 @@ pub use self::{inline_vec::InlineVec, ser_vec::SerVec};
 /// A wrapper which aligns its inner value to 16 bytes.
 #[derive(Clone, Copy, Debug)]
 #[repr(C, align(16))]
-pub struct Align<T>(
+pub struct Align<T: ?Sized>(
     /// The inner value.
     pub T,
 );
 
-impl<T> Deref for Align<T> {
+impl<T: ?Sized> Deref for Align<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -29,7 +29,7 @@ impl<T> Deref for Align<T> {
     }
 }
 
-impl<T> DerefMut for Align<T> {
+impl<T: ?Sized> DerefMut for Align<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }


### PR DESCRIPTION
This allows it to be used with include_bytes to embedded serialized data into the binary:

```rust
use rkyv::{Archive, util::Align, rancor::Error};

#[derive(Archive)]
struct Example {
    name: String,
    value: i32,
}

const SLICE: &Align<[u8]> = &Align(*include_bytes!(concat!(
    env!("OUT_DIR"),
    "/data/test.rkyv"
)));

let archived = rkyv::access::<ArchivedExample, Error>(SLICE).unwrap();
```

Inspired by https://users.rust-lang.org/t/can-i-conveniently-compile-bytes-into-a-rust-program-with-a-specific-alignment/24049/2

I wanted to also add it as a doctest / example, but that would require the rkyv data existing before the test is compiling. Alternatively we could show a const but use a lazy static (e.g. using `LazyLock`), but I'm not sure it would be worth the extra complexity (but I'm willing to do that).
