### PR TITLE
Add `bytemuck` and `zerocopy` feature passthrough to rend

### DIFF
--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -59,6 +59,8 @@ pointer_width_64 = []
 alloc = ["dep:hashbrown", "tinyvec-1?/alloc", "rancor/alloc"]
 std = ["alloc", "bytes-1?/std", "indexmap-2?/std", "ptr_meta/std", "uuid-1?/std"]
 bytecheck = ["dep:bytecheck", "rend/bytecheck", "rkyv_derive/bytecheck"]
+bytemuck = ["rend/bytemuck-1"]
+zerocopy = ["rend/zerocopy-0_8"]
 
 # External crate support
 hashbrown-0_17 = ["dep:hashbrown"]

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -137,6 +137,11 @@
 //! - `std`: Enables standard library support. Enabled by default.
 //! - `bytecheck`: Enables data validation through `bytecheck`. Enabled by
 //!   default.
+//! - `bytemuck`: Enables `bytemuck::Pod` and `Zeroable` impls on rend's
+//!   archived primitive types (passthrough to `rend/bytemuck-1`).
+//! - `zerocopy`: Enables `zerocopy::FromBytes`, `IntoBytes`, `Immutable`,
+//!   and `KnownLayout` impls on rend's archived primitive types
+//!   (passthrough to `rend/zerocopy-0_8`).
 //!
 //! ### Crates
 //!


### PR DESCRIPTION
Mirrors the existing `bytecheck` passthrough: rend already exposes `bytemuck::Pod`/`Zeroable` and `zerocopy::FromBytes`/`IntoBytes`/`Immutable`/`KnownLayout` for its archived primitive types behind its own `bytemuck-1` / `zerocopy-0_8` features, but downstream crates (e.g. `half`) currently have to take a direct dep on `rend` to activate them. Now they can just enable `rkyv/bytemuck` or `rkyv/zerocopy`.

Concrete motivation: needed by VoidStarKat/half-rs#150 to derive zerocopy traits on the rkyv-generated `Archivedf16` / `Archivedbf16` types without half taking a direct dep on rend.
