### PR TITLE
Use checked arithmetic in Arena::with_capacity

### DIFF
--- a/rkyv/src/ser/allocator/alloc.rs
+++ b/rkyv/src/ser/allocator/alloc.rs
@@ -97,7 +97,10 @@ impl Arena {
 
     /// Creates a new `Arena` with at least the requested capacity.
     pub fn with_capacity(cap: usize) -> Self {
-        let head_size = (cap + size_of::<Block>()).next_power_of_two();
+        let head_size = cap
+            .checked_add(size_of::<Block>())
+            .and_then(|s| s.checked_next_power_of_two())
+            .expect("Arena capacity overflow");
         let head_ptr = Block::alloc(head_size);
         Self { head_ptr }
     }


### PR DESCRIPTION
`with_capacity` uses `next_power_of_two()` which can wrap to 0 in release mode for very large inputs. This could cause `Block::alloc` to receive a size smaller than `size_of::<Block>()`, resulting in an undersized write and UB.

Switched to `checked_add` + `checked_next_power_of_two` so it panics instead of wrapping.
Happy to adjust if you'd prefer a different approach.